### PR TITLE
fix: Ignore trailing slash in Spoolman's URL (GH-31)

### DIFF
--- a/octoprint_Spoolman/modules/SpoolmanConnector.py
+++ b/octoprint_Spoolman/modules/SpoolmanConnector.py
@@ -6,9 +6,17 @@ from requests.adapters import HTTPAdapter, Retry
 
 class SpoolmanConnector():
     def __init__(self, instanceUrl, logger, verifyConfig):
-        self.instanceUrl = instanceUrl
+        self.instanceUrl = self._cleanupInstanceUrl(instanceUrl)
         self._logger = logger
         self.verifyConfig = verifyConfig
+
+    def _cleanupInstanceUrl(self, value):
+        trailingSlash = "/"
+
+        if value.endswith(trailingSlash):
+            value = value[:-len(trailingSlash)]
+
+        return value
 
     def _createSpoolmanApiUrl(self):
         apiPath = "/api/v1"


### PR DESCRIPTION
## Description

Changelog:
- Spoolman connector now ignores trailing slash for users convenience

## Related Issue / Discussion

#31 

## How has this been tested?

- Spoolman's URL provided with or without trailing slash

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have verified that my changes do not break the overall functionality of the plugin.
