### PR TITLE
fix: Protect against incomplete data coming from Spoolman (GH-43)

### DIFF
--- a/octoprint_Spoolman/SpoolmanPlugin.py
+++ b/octoprint_Spoolman/SpoolmanPlugin.py
@@ -88,6 +88,7 @@ class SpoolmanPlugin(
                 "js/common/api.js",
                 "js/common/promiseCache.js",
                 "js/common/octoprint.js",
+                "js/common/formatting.js",
                 "js/api/getSpoolmanSpools.js",
                 "js/api/getCurrentJobRequirements.js",
                 "js/api/updateActiveSpool.js",

--- a/octoprint_Spoolman/static/js/Spoolman_api.js
+++ b/octoprint_Spoolman/static/js/Spoolman_api.js
@@ -1,20 +1,21 @@
-$(() => {
+const createApi = () => {
     // from setup.py plugin_identifier
     const PLUGIN_ID = "Spoolman";
 
     const cache = new PromiseCache();
     const apiClient = new APIClient(PLUGIN_ID, BASEURL);
 
+    const sharedGetSpoolmanSpools = async () => {
+        const request = await getSpoolmanSpools(apiClient);
+
+        if (!request.isSuccess) {
+            console.error("Request error", request.error);
+        }
+
+        return request;
+    };
     const cacheGetSpoolmanSpoolsResult = cache.registerResource("getSpoolmanSpools", {
-        getter: async () => {
-            const request = await getSpoolmanSpools(apiClient);
-
-            if (!request.isSuccess) {
-                console.error("Request error", request.error);
-            }
-
-            return request;
-        },
+        getter: sharedGetSpoolmanSpools,
     });
     const sharedGetCurrentJobRequirements = async () => {
         const request = await getCurrentJobRequirements(apiClient);
@@ -25,6 +26,9 @@ $(() => {
 
         return request;
     };
+    /**
+     * @param {Parameters<typeof updateActiveSpool>[1]} params
+     */
     const sharedUpdateActiveSpool = async ({ toolIdx, spoolId }) => {
         const request = await updateActiveSpool(apiClient, { toolIdx, spoolId });
 
@@ -39,11 +43,30 @@ $(() => {
         throw new Error('[Spoolman][api] Could not create cached "getSpoolmanSpools"');
     }
 
-    window.pluginSpoolmanApi = {
+    const pluginSpoolmanApiNamespace = {
         cache,
 
+        /** @type {typeof sharedGetSpoolmanSpools & { invalidate: CachedGetterFn['invalidate'] }} */
+        // @ts-ignore
         getSpoolmanSpools: cacheGetSpoolmanSpoolsResult.getter,
         getCurrentJobRequirements: sharedGetCurrentJobRequirements,
         updateActiveSpool: sharedUpdateActiveSpool,
     };
-});
+
+    /**
+     * @typedef {typeof pluginSpoolmanApiNamespace} PluginSpoolmanApiType
+     */
+
+    // @ts-ignore
+    window.pluginSpoolmanApi = pluginSpoolmanApiNamespace;
+
+    return {
+        pluginSpoolmanApiNamespace,
+    };
+};
+
+$(createApi);
+
+/**
+ * @typedef {ReturnType<typeof createApi>['pluginSpoolmanApiNamespace']} PluginSpoolmanApiType
+ */

--- a/octoprint_Spoolman/static/js/Spoolman_modal_confirmSpool.js
+++ b/octoprint_Spoolman/static/js/Spoolman_modal_confirmSpool.js
@@ -169,6 +169,16 @@ $(() => {
                         : undefined
                 ),
                 (
+                    selectedSpools.some((spool) => {
+                        return (
+                            spool.isToolInUse &&
+                            spool.isSpoolValid === false
+                        );
+                    })
+                        ? self.constants.filament_problems.INVALID_SPOOL
+                        : undefined
+                ),
+                (
                     selectedSpools.some((spool) => spool.isToolMissingSelection === true)
                         ? self.constants.filament_problems.MISSING_SPOOL_SELECTION
                         : undefined
@@ -217,6 +227,7 @@ $(() => {
             length_unit: 'mm',
 
             filament_problems: {
+                INVALID_SPOOL: 'INVALID_SPOOL',
                 NO_FILAMENT_USAGE_DATA: 'NO_FILAMENT_USAGE_DATA',
                 NOT_ENOUGH_FILAMENT: 'NOT_ENOUGH_FILAMENT',
                 MISSING_SPOOL_SELECTION: 'MISSING_SPOOL_SELECTION',

--- a/octoprint_Spoolman/static/js/Spoolman_modal_confirmSpool.js
+++ b/octoprint_Spoolman/static/js/Spoolman_modal_confirmSpool.js
@@ -20,6 +20,8 @@ $(() => {
      * Events:
      * - onConfirm
      * - onHidden
+     *
+     * @param {*} params
      */
     function SpoolmanModalConfirmSpoolViewModel(params) {
         const self = this;

--- a/octoprint_Spoolman/static/js/Spoolman_modal_confirmSpool.js
+++ b/octoprint_Spoolman/static/js/Spoolman_modal_confirmSpool.js
@@ -128,13 +128,19 @@ $(() => {
                 }
 
                 const isToolMissingSelection = !toolFilamentUsage.spoolId;
-                const isEnoughFilamentAvailable = isToolMissingSelection || !spoolData
-                    ? undefined
-                    : toolFilamentUsage.filamentWeight <= spoolData.remaining_weight;
+                const safeSpool = spoolData && toSafeSpool(spoolData);
+
+                const isEnoughFilamentAvailable = (
+                    !isToolMissingSelection &&
+                    safeSpool &&
+                    safeSpool.isSpoolValid
+                )
+                    ? toolFilamentUsage.filamentWeight <= safeSpool.spoolData.remaining_weight
+                    : undefined;
 
                 return {
                     spoolId,
-                    spoolData,
+                    spoolData: safeSpool && safeSpool.spoolData,
                     /** @type true */
                     isToolInUse: true,
                     isToolMissingSelection,

--- a/octoprint_Spoolman/static/js/Spoolman_modal_confirmSpool.js
+++ b/octoprint_Spoolman/static/js/Spoolman_modal_confirmSpool.js
@@ -111,6 +111,8 @@ $(() => {
                 const spoolId = selectedSpoolIds[extruderIdx]?.spoolId();
 
                 const spoolData = spoolmanSpools.find((spool) => String(spool.id) === spoolId);
+                const safeSpool = spoolData && toSafeSpool(spoolData);
+                const spoolDisplayData = spoolData && toSpoolForDisplay(spoolData, { constants: self.constants });
                 const toolFilamentUsage = currentJobRequirements.tools[extruderIdx];
 
                 if (
@@ -120,6 +122,8 @@ $(() => {
                     return {
                         spoolId,
                         spoolData,
+                        spoolDisplayData,
+                        isSpoolValid: safeSpool?.isSpoolValid,
                         /** @type false */
                         isToolInUse: false,
                         isToolMissingSelection: undefined,
@@ -128,7 +132,6 @@ $(() => {
                 }
 
                 const isToolMissingSelection = !toolFilamentUsage.spoolId;
-                const safeSpool = spoolData && toSafeSpool(spoolData);
 
                 const isEnoughFilamentAvailable = (
                     !isToolMissingSelection &&
@@ -141,6 +144,8 @@ $(() => {
                 return {
                     spoolId,
                     spoolData: safeSpool && safeSpool.spoolData,
+                    spoolDisplayData,
+                    isSpoolValid: safeSpool?.isSpoolValid,
                     /** @type true */
                     isToolInUse: true,
                     isToolMissingSelection,

--- a/octoprint_Spoolman/static/js/Spoolman_modal_selectSpool.js
+++ b/octoprint_Spoolman/static/js/Spoolman_modal_selectSpool.js
@@ -69,7 +69,12 @@ $(() => {
                 return String(spool.id) === toolSpoolId;
             });
 
-            const spoolmanSafeSpools = spoolmanSpools.map(toSafeSpool);
+            const spoolmanSafeSpools = spoolmanSpools.map((spool) => {
+                return {
+                    ...toSafeSpool(spool),
+                    displayData: toSpoolForDisplay(spool, { constants: self.constants }),
+                };
+            });
 
             self.templateData.toolCurrentSpoolId(toolSpoolId);
             self.templateData.toolCurrentSpool(

--- a/octoprint_Spoolman/static/js/Spoolman_modal_selectSpool.js
+++ b/octoprint_Spoolman/static/js/Spoolman_modal_selectSpool.js
@@ -79,7 +79,10 @@ $(() => {
             self.templateData.toolCurrentSpoolId(toolSpoolId);
             self.templateData.toolCurrentSpool(
                 toolSpool
-                    ? toSafeSpool(toolSpool)
+                    ? {
+                        ...toSafeSpool(toolSpool),
+                        displayData: toSpoolForDisplay(toolSpool, { constants: self.constants }),
+                    }
                     : undefined
             );
             self.templateData.tableItemsOnCurrentPage(spoolmanSafeSpools);

--- a/octoprint_Spoolman/static/js/Spoolman_modal_selectSpool.js
+++ b/octoprint_Spoolman/static/js/Spoolman_modal_selectSpool.js
@@ -69,9 +69,15 @@ $(() => {
                 return String(spool.id) === toolSpoolId;
             });
 
+            const spoolmanSafeSpools = spoolmanSpools.map(toSafeSpool);
+
             self.templateData.toolCurrentSpoolId(toolSpoolId);
-            self.templateData.toolCurrentSpool(toolSpool);
-            self.templateData.tableItemsOnCurrentPage(spoolmanSpools);
+            self.templateData.toolCurrentSpool(
+                toolSpool
+                    ? toSafeSpool(toolSpool)
+                    : undefined
+            );
+            self.templateData.tableItemsOnCurrentPage(spoolmanSafeSpools);
 
             self.templateData.spoolmanUrl(getPluginSettings().spoolmanUrl());
 

--- a/octoprint_Spoolman/static/js/Spoolman_sidebar.js
+++ b/octoprint_Spoolman/static/js/Spoolman_sidebar.js
@@ -84,6 +84,7 @@ $(() => {
                 return {
                     spoolId,
                     spoolData,
+                    spoolDisplayData: spoolData && toSpoolForDisplay(spoolData, { constants: self.constants }),
                 };
             });
 

--- a/octoprint_Spoolman/static/js/api/getSpoolmanSpools.js
+++ b/octoprint_Spoolman/static/js/api/getSpoolmanSpools.js
@@ -3,6 +3,10 @@
  * @property {Object} data
  * @property {Array<Spool>} data.spools
  *
+ * @typedef {Object} FilamentVendor
+ * @property {number} id
+ * @property {string} name
+ *
  * @typedef {Object} Spool
  * @property {number} id
  * @property {boolean} archived
@@ -21,9 +25,7 @@
  * @property {string | undefined} filament.material
  * @property {string | undefined} filament.name
  * @property {string | undefined} filament.color_hex
- * @property {Object | undefined} filament.vendor
- * @property {number} filament.vendor.id
- * @property {string} filament.vendor.name
+ * @property {FilamentVendor | undefined} filament.vendor
  */
 
 /**

--- a/octoprint_Spoolman/static/js/api/getSpoolmanSpools.js
+++ b/octoprint_Spoolman/static/js/api/getSpoolmanSpools.js
@@ -41,3 +41,33 @@ async function getSpoolmanSpools(apiClient) {
 
     return /** @type Success<{ response: GetSpoolsResponse }> */ (request);
 }
+
+/**
+ * @type {(spool: Spool) => spool is Spool & { remaining_weight: number }}
+ */
+const isSpoolValid = (spool) => {
+    return (
+        spool.remaining_weight !== undefined
+    );
+};
+
+/**
+ * @param {Spool} spool
+ */
+const toSafeSpool = (spool) => {
+    if (isSpoolValid(spool)) {
+        return {
+            spoolId: spool.id,
+            /** @type true */
+            isSpoolValid: true,
+            spoolData: spool,
+        };
+    }
+
+    return {
+        spoolId: spool.id,
+        /** @type false */
+        isSpoolValid: false,
+        spoolData: spool,
+    };
+};

--- a/octoprint_Spoolman/static/js/api/getSpoolmanSpools.js
+++ b/octoprint_Spoolman/static/js/api/getSpoolmanSpools.js
@@ -9,20 +9,19 @@
  * @property {string} registered
  * @property {number} used_length
  * @property {number} used_weight
- * @property {number} remaining_length
- * @property {number} remaining_weight
- * @property {boolean} archived
+ * @property {number | undefined} remaining_length
+ * @property {number | undefined} remaining_weight
  * @property {Object} filament
  * @property {number} filament.id
+ * @property {string} filament.registered
  * @property {number} filament.diameter
  * @property {number} filament.density
- * @property {number} filament.weight
- * @property {number} filament.spool_weight
- * @property {string} filament.material
- * @property {string} filament.name
- * @property {string} filament.registered
- * @property {string} filament.color_hex
- * @property {Object} filament.vendor
+ * @property {number | undefined} filament.weight
+ * @property {number | undefined} filament.spool_weight
+ * @property {string | undefined} filament.material
+ * @property {string | undefined} filament.name
+ * @property {string | undefined} filament.color_hex
+ * @property {Object | undefined} filament.vendor
  * @property {number} filament.vendor.id
  * @property {string} filament.vendor.name
  */

--- a/octoprint_Spoolman/static/js/api/getSpoolmanSpools.js
+++ b/octoprint_Spoolman/static/js/api/getSpoolmanSpools.js
@@ -48,6 +48,9 @@ async function getSpoolmanSpools(apiClient) {
 }
 
 /**
+ * Checks whether spool has "complete-enough" data, so that the plugin
+ * can function properly.
+ *
  * @type {(spool: Spool) => spool is Spool & { remaining_weight: number }}
  */
 const isSpoolValid = (spool) => {

--- a/octoprint_Spoolman/static/js/api/getSpoolmanSpools.js
+++ b/octoprint_Spoolman/static/js/api/getSpoolmanSpools.js
@@ -36,7 +36,10 @@ async function getSpoolmanSpools(apiClient) {
         return request;
     }
     if (!request.payload.response) {
-        return /** @type Success<{ response: undefined }> */ (request);
+        return /** @type Failure<undefined> */ ({
+            isSuccess: false,
+            error: undefined,
+        });
     }
 
     return /** @type Success<{ response: GetSpoolsResponse }> */ (request);

--- a/octoprint_Spoolman/static/js/common/api.js
+++ b/octoprint_Spoolman/static/js/common/api.js
@@ -76,6 +76,9 @@ const methodsWithBody = [
  * @param {string} baseUrl
  */
 function APIClient(pluginId, baseUrl) {
+    /**
+     * @param {string | Record<string, string>} data
+     */
     const _buildRequestQuery = function (data) {
         if (typeof (data) === 'string') {
             return data;
@@ -92,10 +95,20 @@ function APIClient(pluginId, baseUrl) {
             .join('&');
     };
 
+    /**
+     * @param {string} url
+     */
     const buildApiUrl = (url) => {
         return `${baseUrl}plugin/${pluginId}/${url}`;
     };
 
+    /**
+     * @param {{
+     *  method?: string;
+     *  headers?: Record<string, string>;
+     *  body?: string;
+     * }} options
+     */
     const buildFetchOptions = (options) => {
         const requestMethod = (options.method ?? "GET").toUpperCase();
 
@@ -120,7 +133,7 @@ function APIClient(pluginId, baseUrl) {
 
     /**
      * @param {string} url
-     * @param {Object} options
+     * @param {Parameters<typeof buildFetchOptions>[0]} options
      */
     const callApi = async (url, options) => {
         const endpointUrl = buildApiUrl(url);

--- a/octoprint_Spoolman/static/js/common/formatting.js
+++ b/octoprint_Spoolman/static/js/common/formatting.js
@@ -1,0 +1,65 @@
+/**
+ * @param {Spool} spool
+ * @param {{
+*  constants: Record<string, unknown>
+* }} params
+*/
+const toSpoolForDisplay = (spool, params) => {
+    return {
+        filament: {
+            color: {
+                cssProperty: (
+                    spool.filament.color_hex
+                        ? 'background-color'
+                        : 'background'
+                ),
+                cssValue: (
+                    spool.filament.color_hex
+                        ? `#${spool.filament.color_hex}`
+                        : 'linear-gradient(45deg, #000000 -25%, #ffffff)'
+                ),
+            },
+            name: (
+                spool.filament.name
+                    ? {
+                        displayValue: spool.filament.name,
+                    } : {
+                        displayValue: "Unnamed filament",
+                    }
+            ),
+            material: (
+                spool.filament.material
+                    ? {
+                        displayShort: spool.filament.material,
+                        displayValue: spool.filament.material,
+                    } : {
+                        displayShort: "Unknown",
+                        displayValue: "Unknown material",
+                    }
+            ),
+            vendor: {
+                name: (
+                    spool.filament.vendor?.name
+                        ? {
+                            displayValue: spool.filament.vendor.name,
+                        } : {
+                            displayValue: "Unknown filament vendor",
+                        }
+                ),
+            },
+        },
+        used_weight: {
+            displayValue: spool.used_weight.toFixed(1),
+        },
+        remaining_weight: (
+            spool.remaining_weight !== undefined
+                ? {
+                    isValid: true,
+                    displayValue: `${spool.remaining_weight.toFixed(1)}${params.constants['weight_unit']}`,
+                } : {
+                    isValid: false,
+                    displayValue: "Unavailable",
+                }
+        ),
+    };
+};

--- a/octoprint_Spoolman/static/js/types/global.d.ts
+++ b/octoprint_Spoolman/static/js/types/global.d.ts
@@ -1,0 +1,60 @@
+declare global {
+    // Plugin global definitions
+    const pluginSpoolmanApi: PluginSpoolmanApiType;
+
+    // Octoprint related definitions
+    const OctoPrint: {
+        socket: {
+            onMessage: (
+                messageType: string,
+                callback: (message: {
+                    data: {
+                        type?: string;
+                        payload: unknown;
+                    };
+                }) => void
+            ) => void;
+        };
+    };
+    const OctoPrintClient: {
+        new(params: unknown): typeof OctoPrintClient;
+
+        getCookie: (name: string) => string;
+    };
+    const OCTOPRINT_VIEWMODELS: {
+        push: (viewModel: {
+            construct: unknown;
+            dependencies: string[];
+            elements: (Element | null)[];
+        }) => void;
+    };
+
+    const PNotify: {
+        new (params: {
+            title: string;
+            text: string;
+            type: string;
+            hide: boolean;
+            addclass: string;
+        }): void
+    };
+
+    const BASEURL: string;
+
+    // Knockout
+    const ko: {
+        observable: <ValueType extends unknown>(arg?: ValueType) => ((value: ValueType) => void);
+        components: {
+            register: (name: string, params: { viewModel: unknown; template: Record<string, string>}) => void;
+        };
+    };
+
+    // jQuery
+    const $: {
+        (...args: unknown[]): typeof $;
+
+        on(eventName: string, selector: string, callback: () => void): void;
+    };
+}
+
+export {}

--- a/octoprint_Spoolman/templates/Spoolman_modal_confirmspool.jinja2
+++ b/octoprint_Spoolman/templates/Spoolman_modal_confirmspool.jinja2
@@ -95,7 +95,7 @@
 
             <div data-bind="foreach: templateData.selectedSpoolsByToolIdx">
                 <div class="tool-row">
-                    <!-- ko ifnot: $data.spoolId && $data.spoolData -->
+                    <!-- ko ifnot: $data.spoolId && $data.spoolData && $data.spoolDisplayData -->
                         <div style="display: flex;">
                             <!-- ko if: $parent.templateData.selectedSpoolsByToolIdx().length > 1 -->
                                 <div class="tool-idx" style="margin-right: 0.25em;">
@@ -126,7 +126,7 @@
                                             </strong>
                                         <!-- /ko -->
                                         <!-- ko if: ($data.filamentUsage.isEnough === undefined) -->
-                                            <strong class="text-error">
+                                            <strong class="text-warning">
                                                 <span
                                                     data-bind="text: ($data.filamentUsage.length ?? 0).toFixed(1)"
                                                     title="Required length"
@@ -144,7 +144,7 @@
                         </div>
                     <!-- /ko -->
 
-                    <!-- ko if: $data.spoolData -->
+                    <!-- ko if: $data.spoolData && $data.spoolDisplayData -->
                         <div style="display: flex;">
                             <!-- ko if: $parent.templateData.selectedSpoolsByToolIdx().length > 1 -->
                                 <div class="tool-idx" style="margin-right: 0.25em;">
@@ -155,16 +155,24 @@
                             <span
                                 class="color-preview"
                                 style="flex-shrink: 0;"
-                                data-bind="style: { 'background-color': '#' + spoolData.filament.color_hex }, attr: { title: spoolData.filament.name }"
+                                data-bind="
+                                    style: { [$data.spoolDisplayData.filament.color.cssProperty]: $data.spoolDisplayData.filament.color.cssValue },
+                                    attr: { title: $data.spoolDisplayData.filament.name.displayValue }
+                                "
                             ></span>
                             <div class="spool-label">
-                                <!-- ko if: spoolData.filament.material -->
-                                <span>[<span data-bind="text: spoolData.filament.material"></span>]</span>
-                                <!-- /ko -->
-                                <span data-bind="text: spoolData.filament.name"></span>
-                                <!-- ko if: spoolData.filament.vendor.name -->
-                                <span>(<span data-bind="text: spoolData.filament.vendor.name"></span>)</span>
-                                <!-- /ko -->
+                                <span>[<span data-bind="
+                                    text: $data.spoolDisplayData.filament.material.displayShort,
+                                    attr: { title: $data.spoolDisplayData.filament.material.displayValue }
+                                "></span>]</span>
+                                <span data-bind="
+                                    text: $data.spoolDisplayData.filament.name.displayValue,
+                                    attr: { title: $data.spoolDisplayData.filament.name.displayValue }
+                                "></span>
+                                <i>(<span data-bind="
+                                    text: $data.spoolDisplayData.filament.vendor.name.displayValue,
+                                    attr: { title: $data.spoolDisplayData.filament.vendor.name.displayValue }
+                                "></span>)</i>
                             </div>
                         </div>
                         <div style="display: flex; flex-direction: column; flex-shrink: 0;">
@@ -172,7 +180,17 @@
                                 <div class="text-right">
                                     <span>
                                         Required:
-                                        <strong data-bind="class: ($data.filamentUsage?.isEnough ?? false) ? 'text-success' : 'text-error'">
+                                        <strong data-bind="
+                                            class: (
+                                                $data.filamentUsage?.isEnough === undefined
+                                                    ? 'text-warning'
+                                                    : (
+                                                        $data.filamentUsage?.isEnough === true
+                                                        ? 'text-success'
+                                                        : 'text-error'
+                                                    )
+                                            )
+                                        ">
                                             <span
                                                 data-bind="text: ($data.filamentUsage?.weight ?? 0).toFixed(1)"
                                                 title="Required weight"
@@ -183,11 +201,8 @@
                                 <div class="text-right">
                                     <span>
                                         Remaining on spool:
-                                        <strong>
-                                            <span
-                                                data-bind="text: (spoolData.remaining_weight ?? 0).toFixed(1)"
-                                                title="Remaining weight"
-                                            ></span><span data-bind="text: $root.constants.weight_unit"></span>
+                                        <strong data-bind="class: ($data.spoolDisplayData.remaining_weight.isValid) ? '' : 'text-error'">
+                                            <span data-bind="text: $data.spoolDisplayData.remaining_weight.displayValue, attr: {title: 'Remaining weight'}"></span>
                                         </strong>
                                     </span>
                                 </div>

--- a/octoprint_Spoolman/templates/Spoolman_modal_confirmspool.jinja2
+++ b/octoprint_Spoolman/templates/Spoolman_modal_confirmspool.jinja2
@@ -81,6 +81,9 @@
                                 <!-- ko if: (templateData.detectedProblems().includes(constants.filament_problems.NOT_ENOUGH_FILAMENT)) -->
                                     <li>One of the selected spools does not have enough filament.</li>
                                 <!-- /ko -->
+                                <!-- ko if: (templateData.detectedProblems().includes(constants.filament_problems.INVALID_SPOOL)) -->
+                                    <li>One of the selected spools does not include all necessary information.</li>
+                                <!-- /ko -->
                                 <!-- ko if: (templateData.detectedProblems().includes(constants.filament_problems.MISSING_SPOOL_SELECTION)) -->
                                     <li>One of the tools is missing spool selection.</li>
                                 <!-- /ko -->

--- a/octoprint_Spoolman/templates/Spoolman_sidebar.jinja2
+++ b/octoprint_Spoolman/templates/Spoolman_sidebar.jinja2
@@ -72,7 +72,7 @@
                     </div>
                 <!-- /ko -->
 
-                <!-- ko ifnot: $data.spoolId && $data.spoolData -->
+                <!-- ko ifnot: $data.spoolId && $data.spoolData && $data.spoolDisplayData -->
                     <div class="spool-label">
                         <!-- ko if: $data.spoolId -->
                             <i class="text-error">Unknown spool selected</i>
@@ -103,25 +103,34 @@
                     </div>
                 <!-- /ko -->
 
-                <!-- ko if: $data.spoolData -->
+                <!-- ko if: $data.spoolData && $data.spoolDisplayData -->
                     <div>
                         <span
                             class="color-preview"
-                            data-bind="style: { 'background-color': '#' + spoolData.filament.color_hex }, attr: { title: spoolData.filament.name }"
+                            data-bind="
+                                style: { [$data.spoolDisplayData.filament.color.cssProperty]: $data.spoolDisplayData.filament.color.cssValue },
+                                attr: { title: $data.spoolDisplayData.filament.name.displayValue }
+                            "
                         ></span>
                     </div>
                     <div class="spool-label">
-                        <!-- ko if: spoolData.filament.material -->
-                        <span>[<span data-bind="text: spoolData.filament.material"></span>]</span>
-                        <!-- /ko -->
-                        <span data-bind="text: spoolData.filament.name"></span>
-                        <!-- ko if: spoolData.filament.vendor.name -->
-                        <span>(<span data-bind="text: spoolData.filament.vendor.name"></span>)</span>
-                        <!-- /ko -->
-                        <span><span
-                            data-bind="text: (spoolData.remaining_weight ?? 0).toFixed(1)"
-                            title="Remaining weight"
-                        ></span><span data-bind="text: $root.constants.weight_unit"></span></span>
+                        <span>[<span data-bind="
+                            text: $data.spoolDisplayData.filament.material.displayShort,
+                            attr: { title: $data.spoolDisplayData.filament.material.displayValue }
+                        "></span>]</span>
+                        <span data-bind="
+                            text: $data.spoolDisplayData.filament.name.displayValue,
+                            attr: { title: $data.spoolDisplayData.filament.name.displayValue }
+                        "></span>
+                        <i>(<span data-bind="
+                            text: $data.spoolDisplayData.filament.vendor.name.displayValue,
+                            attr: { title: $data.spoolDisplayData.filament.vendor.name.displayValue }
+                        "></span>)</i>
+                        <span><span data-bind="
+                            text: $data.spoolDisplayData.remaining_weight.displayValue,
+                            attr: {title: 'Remaining weight'},
+                            class: ($data.spoolDisplayData.remaining_weight.isValid) ? '' : 'text-error'
+                        "></span></span>
                     </div>
                     <div>
                         <div class="btn-group">

--- a/octoprint_Spoolman/templates/Spoolman_sidebar.jinja2
+++ b/octoprint_Spoolman/templates/Spoolman_sidebar.jinja2
@@ -66,22 +66,24 @@
             data-bind="foreach: templateData.selectedSpoolsByToolIdx"
         >
             <div class="tool-row">
-                <!-- ko if: $parent.templateData.selectedSpoolsByToolIdx().length > 1 -->
-                    <div class="tool-idx">
-                        <b>Tool #<span data-bind="text: $index()"></span>:</b>
-                    </div>
-                <!-- /ko -->
-
                 <!-- ko ifnot: $data.spoolId && $data.spoolData && $data.spoolDisplayData -->
-                    <div class="spool-label">
-                        <!-- ko if: $data.spoolId -->
-                            <i class="text-error">Unknown spool selected</i>
+                    <div style="display: flex;">
+                        <!-- ko if: $parent.templateData.selectedSpoolsByToolIdx().length > 1 -->
+                            <div class="tool-idx" style="margin-right: 0.25em;">
+                                <b>Tool #<span data-bind="text: $index()"></span>:</b>
+                            </div>
                         <!-- /ko -->
-                        <!-- ko ifnot: $data.spoolId -->
-                            <i class="muted">No spool selected</i>
-                        <!-- /ko -->
+
+                        <div class="spool-label">
+                            <!-- ko if: $data.spoolId -->
+                                <i class="text-error">Unknown spool selected</i>
+                            <!-- /ko -->
+                            <!-- ko ifnot: $data.spoolId -->
+                                <i class="muted">No spool selected</i>
+                            <!-- /ko -->
+                        </div>
                     </div>
-                    <div>
+                    <div style="display: flex; flex-shrink: 0;">
                         <div class="btn-group">
                             <!-- ko if: $data.spoolId -->
                                 <button
@@ -104,35 +106,44 @@
                 <!-- /ko -->
 
                 <!-- ko if: $data.spoolData && $data.spoolDisplayData -->
-                    <div>
-                        <span
-                            class="color-preview"
-                            data-bind="
-                                style: { [$data.spoolDisplayData.filament.color.cssProperty]: $data.spoolDisplayData.filament.color.cssValue },
+                    <div style="display: flex;">
+                        <!-- ko if: $parent.templateData.selectedSpoolsByToolIdx().length > 1 -->
+                            <div class="tool-idx" style="margin-right: 0.25em;">
+                                <b>Tool #<span data-bind="text: $index()"></span>:</b>
+                            </div>
+                        <!-- /ko -->
+
+                        <div>
+                            <span
+                                class="color-preview"
+                                style="flex-shrink: 0;"
+                                data-bind="
+                                    style: { [$data.spoolDisplayData.filament.color.cssProperty]: $data.spoolDisplayData.filament.color.cssValue },
+                                    attr: { title: $data.spoolDisplayData.filament.name.displayValue }
+                                "
+                            ></span>
+                        </div>
+                        <div class="spool-label">
+                            <span>[<span data-bind="
+                                text: $data.spoolDisplayData.filament.material.displayShort,
+                                attr: { title: $data.spoolDisplayData.filament.material.displayValue }
+                            "></span>]</span>
+                            <span data-bind="
+                                text: $data.spoolDisplayData.filament.name.displayValue,
                                 attr: { title: $data.spoolDisplayData.filament.name.displayValue }
-                            "
-                        ></span>
+                            "></span>
+                            <i>(<span data-bind="
+                                text: $data.spoolDisplayData.filament.vendor.name.displayValue,
+                                attr: { title: $data.spoolDisplayData.filament.vendor.name.displayValue }
+                            "></span>)</i>
+                            <span><span data-bind="
+                                text: $data.spoolDisplayData.remaining_weight.displayValue,
+                                attr: {title: 'Remaining weight'},
+                                class: ($data.spoolDisplayData.remaining_weight.isValid) ? '' : 'text-error'
+                            "></span></span>
+                        </div>
                     </div>
-                    <div class="spool-label">
-                        <span>[<span data-bind="
-                            text: $data.spoolDisplayData.filament.material.displayShort,
-                            attr: { title: $data.spoolDisplayData.filament.material.displayValue }
-                        "></span>]</span>
-                        <span data-bind="
-                            text: $data.spoolDisplayData.filament.name.displayValue,
-                            attr: { title: $data.spoolDisplayData.filament.name.displayValue }
-                        "></span>
-                        <i>(<span data-bind="
-                            text: $data.spoolDisplayData.filament.vendor.name.displayValue,
-                            attr: { title: $data.spoolDisplayData.filament.vendor.name.displayValue }
-                        "></span>)</i>
-                        <span><span data-bind="
-                            text: $data.spoolDisplayData.remaining_weight.displayValue,
-                            attr: {title: 'Remaining weight'},
-                            class: ($data.spoolDisplayData.remaining_weight.isValid) ? '' : 'text-error'
-                        "></span></span>
-                    </div>
-                    <div>
+                    <div style="display: flex; flex-shrink: 0;">
                         <div class="btn-group">
                             <button
                                 class="btn btn-mini"

--- a/octoprint_Spoolman/templates/Spoolman_sidebar_modal_selectspool.jinja2
+++ b/octoprint_Spoolman/templates/Spoolman_sidebar_modal_selectspool.jinja2
@@ -127,6 +127,8 @@
                                 style="cursor: pointer;"
                                 data-bind="
                                     click: function() {
+                                        if (!$data.isSpoolValid) { return; }
+
                                         $component.templateApi.handleSelectSpoolForTool($component.templateData.toolIdx(), $data.spoolId);
                                     },
                                     attr: {
@@ -135,10 +137,15 @@
                                             String($component.templateData.toolCurrentSpool().spoolId) === String($data.spoolId)
                                         )
                                             ? 'success'
-                                            : ''
-                                        }
+                                            : '',
+                                        style: [
+                                            `cursor: ${$data.isSpoolValid ? 'pointer' : 'not-allowed'}`
+                                        ].join(' '),
+                                        title: $data.isSpoolValid
+                                            ? 'Click to select spool'
+                                            : 'Invalid spool, not available for selection'
+                                    }
                                 "
-                                title="Click to select spool"
                             >
                                 <td data-bind="visible: $component.templateData.tableAttributeVisibility.id">
                                     <span data-bind="text: $data.spoolId, attr: { title: $data.spoolId }"></span>

--- a/octoprint_Spoolman/templates/Spoolman_sidebar_modal_selectspool.jinja2
+++ b/octoprint_Spoolman/templates/Spoolman_sidebar_modal_selectspool.jinja2
@@ -148,28 +148,33 @@
                                         <div>
                                             <span
                                                 class="color-preview"
-                                                data-bind="style: { 'background-color': '#' + $data.spoolData.filament.color_hex }, attr: { title: $data.spoolData.filament.name }"
+                                                data-bind="
+                                                    style: { [$data.displayData.filament.color.cssProperty]: $data.displayData.filament.color.cssValue },
+                                                    attr: { title: $data.displayData.filament.name.displayValue }
+                                                "
                                             ></span>
                                         </div>
                                         <div>
-                                            <span data-bind="text: $data.spoolData.filament.name, attr: { title: $data.spoolData.filament.name }"></span>
+                                            <span data-bind="text: $data.displayData.filament.name.displayValue, attr: { title: $data.displayData.filament.name.displayValue }"></span>
                                             <br>
                                             <i>
-                                                <span data-bind="text: $data.spoolData.filament.vendor.name, attr: { title: $data.spoolData.filament.vendor.name }"></span>
+                                                <span data-bind="text: $data.displayData.filament.vendor.name.displayValue, attr: { title: $data.displayData.filament.vendor.name.displayValue }"></span>
                                             </i>
                                         </div>
                                     </div>
                                 </td>
                                 <td data-bind="visible: $component.templateData.tableAttributeVisibility.material">
-                                    <span data-bind="text: $data.spoolData.filament.material, attr: { title: $data.spoolData.filament.material }"></span>
+                                    <span data-bind="text: $data.displayData.filament.material.displayValue, attr: { title: $data.displayData.filament.material.displayValue }"></span>
                                 </td>
                                 <td
                                     data-bind="visible: $component.templateData.tableAttributeVisibility.weight" style="text-align: right;"
                                 >
-                                    <span data-bind="text: ($data.spoolData.remaining_weight ?? 0).toFixed(1), attr: {title: 'Remaining weight'}"></span><span data-bind="text: $component.constants.weight_unit"></span>
+                                    <span data-bind="class: ($data.displayData.remaining_weight.isValid) ? '' : 'text-error'">
+                                        <span data-bind="text: $data.displayData.remaining_weight.displayValue, attr: {title: 'Remaining weight'}"></span>
+                                    </span>
                                     <br>
                                     <span class="muted">
-                                        <span data-bind="text: $data.spoolData.used_weight.toFixed(1), attr: {title: 'Used weight'}"></span><span data-bind="text: $component.constants.weight_unit"></span>
+                                        <span data-bind="text: $data.displayData.used_weight.displayValue, attr: {title: 'Used weight'}"></span><span data-bind="text: $component.constants.weight_unit"></span>
                                     </span>
                                 </td>
                             </tr>

--- a/octoprint_Spoolman/templates/Spoolman_sidebar_modal_selectspool.jinja2
+++ b/octoprint_Spoolman/templates/Spoolman_sidebar_modal_selectspool.jinja2
@@ -25,22 +25,22 @@
                     <span
                         class="color-preview"
                         style="margin-bottom: -5px;"
-                        data-bind="style: { 'background-color': '#' + templateData.toolCurrentSpool().filament.color_hex },
-                                    attr: { title: templateData.toolCurrentSpool().filament.name }"
+                        data-bind="style: { 'background-color': '#' + templateData.toolCurrentSpool().spoolData.filament.color_hex },
+                                    attr: { title: templateData.toolCurrentSpool().spoolData.filament.name }"
                     ></span>
                     <span>
-                        <!-- ko if: templateData.toolCurrentSpool().filament.material -->
-                            <span data-bind="text: templateData.toolCurrentSpool().filament.material"></span> -
+                        <!-- ko if: templateData.toolCurrentSpool().spoolData.filament.material -->
+                            <span data-bind="text: templateData.toolCurrentSpool().spoolData.filament.material"></span> -
                         <!-- /ko -->
 
-                        <span data-bind="text: templateData.toolCurrentSpool().filament.name"></span>
+                        <span data-bind="text: templateData.toolCurrentSpool().spoolData.filament.name"></span>
 
-                        <!-- ko if: templateData.toolCurrentSpool().filament.vendor.name -->
-                            (<span data-bind="text: templateData.toolCurrentSpool().filament.vendor.name"></span>)
+                        <!-- ko if: templateData.toolCurrentSpool().spoolData.filament.vendor.name -->
+                            (<span data-bind="text: templateData.toolCurrentSpool().spoolData.filament.vendor.name"></span>)
                         <!-- /ko -->
 
                         <span
-                            data-bind="text: (templateData.toolCurrentSpool().remaining_weight ?? 0).toFixed(1)"
+                            data-bind="text: (templateData.toolCurrentSpool().spoolData.remaining_weight ?? 0).toFixed(1)"
                             title="Remaining weight"
                         ></span><span data-bind="text: $component.constants.weight_unit"></span>
                     </span>
@@ -127,12 +127,12 @@
                                 style="cursor: pointer;"
                                 data-bind="
                                     click: function() {
-                                        $component.templateApi.handleSelectSpoolForTool($component.templateData.toolIdx(), $data.id);
+                                        $component.templateApi.handleSelectSpoolForTool($component.templateData.toolIdx(), $data.spoolId);
                                     },
                                     attr: {
                                         class: (
                                             $component.templateData.toolCurrentSpool() &&
-                                            String($component.templateData.toolCurrentSpool().id) === String($data.id)
+                                            String($component.templateData.toolCurrentSpool().spoolId) === String($data.spoolId)
                                         )
                                             ? 'success'
                                             : ''
@@ -141,35 +141,35 @@
                                 title="Click to select spool"
                             >
                                 <td data-bind="visible: $component.templateData.tableAttributeVisibility.id">
-                                    <span data-bind="text: id, attr: { title: id }"></span>
+                                    <span data-bind="text: $data.spoolId, attr: { title: $data.spoolId }"></span>
                                 </td>
                                 <td data-bind="visible: $component.templateData.tableAttributeVisibility.spoolName">
                                     <div style="display: flex;">
                                         <div>
                                             <span
                                                 class="color-preview"
-                                                data-bind="style: { 'background-color': '#' + filament.color_hex }, attr: { title: filament.name }"
+                                                data-bind="style: { 'background-color': '#' + $data.spoolData.filament.color_hex }, attr: { title: $data.spoolData.filament.name }"
                                             ></span>
                                         </div>
                                         <div>
-                                            <span data-bind="text: filament.name, attr: { title: filament.name }"></span>
+                                            <span data-bind="text: $data.spoolData.filament.name, attr: { title: $data.spoolData.filament.name }"></span>
                                             <br>
                                             <i>
-                                                <span data-bind="text: filament.vendor.name, attr: { title: filament.vendor.name }"></span>
+                                                <span data-bind="text: $data.spoolData.filament.vendor.name, attr: { title: $data.spoolData.filament.vendor.name }"></span>
                                             </i>
                                         </div>
                                     </div>
                                 </td>
                                 <td data-bind="visible: $component.templateData.tableAttributeVisibility.material">
-                                    <span data-bind="text: filament.material, attr: { title: filament.material }"></span>
+                                    <span data-bind="text: $data.spoolData.filament.material, attr: { title: $data.spoolData.filament.material }"></span>
                                 </td>
                                 <td
                                     data-bind="visible: $component.templateData.tableAttributeVisibility.weight" style="text-align: right;"
                                 >
-                                    <span data-bind="text: (remaining_weight ?? 0).toFixed(1), attr: {title: 'Remaining weight'}"></span><span data-bind="text: $component.constants.weight_unit"></span>
+                                    <span data-bind="text: ($data.spoolData.remaining_weight ?? 0).toFixed(1), attr: {title: 'Remaining weight'}"></span><span data-bind="text: $component.constants.weight_unit"></span>
                                     <br>
                                     <span class="muted">
-                                        <span data-bind="text: used_weight.toFixed(1), attr: {title: 'Used weight'}"></span><span data-bind="text: $component.constants.weight_unit"></span>
+                                        <span data-bind="text: $data.spoolData.used_weight.toFixed(1), attr: {title: 'Used weight'}"></span><span data-bind="text: $component.constants.weight_unit"></span>
                                     </span>
                                 </td>
                             </tr>

--- a/octoprint_Spoolman/templates/Spoolman_sidebar_modal_selectspool.jinja2
+++ b/octoprint_Spoolman/templates/Spoolman_sidebar_modal_selectspool.jinja2
@@ -25,24 +25,29 @@
                     <span
                         class="color-preview"
                         style="margin-bottom: -5px;"
-                        data-bind="style: { 'background-color': '#' + templateData.toolCurrentSpool().spoolData.filament.color_hex },
-                                    attr: { title: templateData.toolCurrentSpool().spoolData.filament.name }"
+                        data-bind="
+                                    style: { [templateData.toolCurrentSpool().displayData.filament.color.cssProperty]: templateData.toolCurrentSpool().displayData.filament.color.cssValue },
+                                    attr: { title: templateData.toolCurrentSpool().displayData.filament.name.displayValue }
+                                "
                     ></span>
                     <span>
-                        <!-- ko if: templateData.toolCurrentSpool().spoolData.filament.material -->
-                            <span data-bind="text: templateData.toolCurrentSpool().spoolData.filament.material"></span> -
-                        <!-- /ko -->
-
-                        <span data-bind="text: templateData.toolCurrentSpool().spoolData.filament.name"></span>
-
-                        <!-- ko if: templateData.toolCurrentSpool().spoolData.filament.vendor.name -->
-                            (<span data-bind="text: templateData.toolCurrentSpool().spoolData.filament.vendor.name"></span>)
-                        <!-- /ko -->
-
-                        <span
-                            data-bind="text: (templateData.toolCurrentSpool().spoolData.remaining_weight ?? 0).toFixed(1)"
-                            title="Remaining weight"
-                        ></span><span data-bind="text: $component.constants.weight_unit"></span>
+                        <span>[<span data-bind="
+                            text: templateData.toolCurrentSpool().displayData.filament.material.displayShort,
+                            attr: { title: templateData.toolCurrentSpool().displayData.filament.material.displayValue }
+                        "></span>]</span>
+                        <span data-bind="
+                            text: templateData.toolCurrentSpool().displayData.filament.name.displayValue,
+                            attr: { title: templateData.toolCurrentSpool().displayData.filament.name.displayValue }
+                        "></span>
+                        <i>(<span data-bind="
+                            text: templateData.toolCurrentSpool().displayData.filament.vendor.name.displayValue,
+                            attr: { title: templateData.toolCurrentSpool().displayData.filament.vendor.name.displayValue }
+                        "></span>)</i>
+                        <span><span data-bind="
+                            text: templateData.toolCurrentSpool().displayData.remaining_weight.displayValue,
+                            attr: {title: 'Remaining weight'},
+                            class: (templateData.toolCurrentSpool().displayData.remaining_weight.isValid) ? '' : 'text-error'
+                        "></span></span>
                     </span>
                 <!-- /ko -->
                 <!-- ko ifnot: templateData.toolCurrentSpool() -->

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "checkJs": true,
+        "strict": true,
+        "typeRoots": [
+            "./octoprint_Spoolman/static/js/types",
+        ],
+        "target": "es2020",
+    },
+    "include": [
+        "./octoprint_Spoolman/static/js/*"
+    ],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,6 @@
         "target": "es2020",
     },
     "include": [
-        "./octoprint_Spoolman/static/js/*"
+        "./octoprint_Spoolman/static/js/**/*"
     ],
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description

Changelog:
- Improve JS code typings quality (Spoolman API & general code)
  - Enable actual TypeScript validation to improve "type recognition"
  - This is still WIP, as there's some validation errors to be fixed still, but that's for another task
- Add protection against incomplete data coming from Spoolman (eg. missing "remaining" data)
- Do not allow to select spools with incomplete data

## Related Issue / Discussion

#43 

## How has this been tested?

- Invalid spool added to Spoolman (typed only required data, and left all non-required fields empty)
  - Note: modifying existing, "valid" spool is not a valid approach
- Spool selector tested with existing incomplete spool
- Sidebar, spool selector & spool confirmation modal tested with pre-selected incomplete spool
  - Tests if users with already existing invalid selections won't encounter any problems
  - Tests if users who accidentally break their Spools in Spoolman won't encounter any problems
- Tested whether "fixing" the Spool in Spoolman makes it correct & available for selection
- Starting print with incomplete spool selected out of scope of this task
  - Users have been warned, so at this point it's either their fault if something breaks, or the warning system is broken, which would be a separate issue to fix
  - Investing in "validate spool before data commit" possible, but would require more time to implement

## Screenshots (if appropriate):

![obraz](https://github.com/mdziekon/octoprint-spoolman/assets/4425221/de560911-3261-45f3-ac1e-f7085701c434)
![obraz](https://github.com/mdziekon/octoprint-spoolman/assets/4425221/f6e768ab-9f61-4831-9d96-9d7e8a555d44)
![obraz](https://github.com/mdziekon/octoprint-spoolman/assets/4425221/7cbce04c-743f-4acc-a31b-0281a4508b1d)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have verified that my changes do not break the overall functionality of the plugin.
