### PR TITLE
fix: Allow multi-instancing of Octoprint (GH-50)

### DIFF
--- a/octoprint_Spoolman/modules/PrinterHandler.py
+++ b/octoprint_Spoolman/modules/PrinterHandler.py
@@ -63,6 +63,8 @@ class PrinterHandler():
         selectedSpoolIds = self._settings.get([SettingsKeys.SELECTED_SPOOL_IDS])
 
         for toolIdx, toolExtrusionLength in enumerate(current_extrusion_stats['extrusionAmount']):
+            selectedSpool = None
+
             try:
                 selectedSpool = selectedSpoolIds[str(toolIdx)]
             except:

--- a/octoprint_Spoolman/static/js/common/api.js
+++ b/octoprint_Spoolman/static/js/common/api.js
@@ -117,13 +117,9 @@ function APIClient(pluginId, baseUrl) {
         };
 
         if (methodsWithBody.includes(requestMethod)) {
-            const stockClient = new OctoPrintClient({
-                baseurl: "/",
-            });
-
             fetchOptions.headers = {
                 'Content-Type': "application/json; charset=UTF-8",
-                'X-CSRF-Token': stockClient.getCookie("csrf_token"),
+                'X-CSRF-Token': OctoPrint.getCookie("csrf_token"),
                 ...(fetchOptions.headers ?? {}),
             };
         }

--- a/octoprint_Spoolman/static/js/types/global.d.ts
+++ b/octoprint_Spoolman/static/js/types/global.d.ts
@@ -2,7 +2,12 @@ declare global {
     // Plugin global definitions
     const pluginSpoolmanApi: PluginSpoolmanApiType;
 
-    // Octoprint related definitions
+    /**
+     * Octoprint related definitions.
+     *
+     * Accessible via `window.OctoPrint` instance exposed by OctoPrint itself
+     * @see https://github.com/OctoPrint/OctoPrint/blob/1.10.0/src/octoprint/static/js/app/main.js#L2
+     */
     const OctoPrint: {
         socket: {
             onMessage: (
@@ -15,10 +20,6 @@ declare global {
                 }) => void
             ) => void;
         };
-    };
-    const OctoPrintClient: {
-        new(params: unknown): typeof OctoPrintClient;
-
         getCookie: (name: string) => string;
     };
     const OCTOPRINT_VIEWMODELS: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes. Please provide context & motivation for the changes. -->

Changelog:
- Use OctoPrints cookie reader directly to prevent baseurl mismatch
  - This should allow multi-instancing of Octoprint to operate correctly

## Related Issue / Discussion

#50

## How has this been tested?

(Regression testing) Singular instance of Octoprint
- Try to select a spool

Expected outcomes:
- Spool should be properly selected

---

Mult-instance of Octoprint
- Not verified

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have verified that my changes do not break the overall functionality of the plugin.
