### PR TITLE
feat: Display filament weight in Printer State view (GH-48)

### DIFF
--- a/octoprint_Spoolman/static/js/common/formatting.js
+++ b/octoprint_Spoolman/static/js/common/formatting.js
@@ -1,3 +1,14 @@
+
+/**
+ * @param {number} weight
+ * @param {{
+*  constants: Record<string, unknown>
+* }} params
+*/
+const toWeight = (weight, params) => {
+    return `${weight.toFixed(1)}${params.constants['weight_unit']}`;
+};
+
 /**
  * @param {Spool} spool
  * @param {{
@@ -55,11 +66,27 @@ const toSpoolForDisplay = (spool, params) => {
             spool.remaining_weight !== undefined
                 ? {
                     isValid: true,
-                    displayValue: `${spool.remaining_weight.toFixed(1)}${params.constants['weight_unit']}`,
+                    displayValue: toWeight(spool.remaining_weight, params),
                 } : {
                     isValid: false,
                     displayValue: "Unavailable",
                 }
         ),
     };
+};
+
+/**
+ * @param {number} length
+ *  Filament path length, in `mm`
+ * @param {number} diameter
+ *  Filament diameter, in `mm`
+ * @param {number} density
+ *  Filament density, in `g/cm^3`
+ * @returns number
+ */
+const calculateWeight = (length, diameter, density) => {
+    const radius = diameter / 2;
+    const volume = length * Math.PI * (radius * radius) / 1000;
+
+    return volume * density;
 };

--- a/octoprint_Spoolman/static/js/types/global.d.ts
+++ b/octoprint_Spoolman/static/js/types/global.d.ts
@@ -40,6 +40,13 @@ declare global {
         }): void
     };
 
+    /**
+     * OctoPrint's filament formatter helper.
+     *
+     * @see https://github.com/OctoPrint/OctoPrint/blob/a8fff3930e3c3901bd560ca77656c281959134b3/src/octoprint/static/js/app/helpers.js#L639
+     */
+    const formatFilament: (filamentData: unknown) => string;
+
     const BASEURL: string;
 
     // Knockout


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description

Changelog:
- Display filament weight alongside filament's length & volume
- Apply color on filament weight / length / volume to signal if it's sufficient or not

## Related Issue / Discussion

#48 

## How has this been tested?

- Select model to verify proper filament display value
  - Single extruder model
  - Multi extruder model

## Screenshots (if appropriate):

![obraz](https://github.com/user-attachments/assets/12cd6eb0-dedd-4580-a0ef-bff23b9f5fbd)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have verified that my changes do not break the overall functionality of the plugin.
