### PR TITLE
Backup

### DIFF
--- a/octoprint_Spoolman/SpoolmanPlugin.py
+++ b/octoprint_Spoolman/SpoolmanPlugin.py
@@ -57,6 +57,7 @@ class SpoolmanPlugin(
 
     def on_after_startup(self):
         self._logger.info("[Spoolman][init] Plugin activated")
+        self.loadSaveSpoolUsage()
 
     # Printing events handlers
     def on_event(self, event, payload):
@@ -68,7 +69,8 @@ class SpoolmanPlugin(
             event == Events.PRINT_CANCELLED
         ):
             self.handlePrintingStatusChange(event)
-
+            self.resetSaveStatus(event)
+                
         pass
 
     def on_sentGCodeHook(self, comm_instance, phase, cmd, cmd_type, gcode, *args, **kwargs):
@@ -76,6 +78,7 @@ class SpoolmanPlugin(
             return
 
         self.handlePrintingGCode(cmd)
+        self.detectLayerChange(cmd)
 
         pass
 
@@ -126,6 +129,8 @@ class SpoolmanPlugin(
             SettingsKeys.SPOOLMAN_CERT_PEM_PATH: "",
             SettingsKeys.SELECTED_SPOOL_IDS: {},
             SettingsKeys.IS_PREPRINT_SPOOL_VERIFY_ENABLED: True,
+            SettingsKeys.STATUS_BACKUP: False,
+            SettingsKeys.BACKUP_DATA: {}
         }
 
         return settings
@@ -141,7 +146,8 @@ class SpoolmanPlugin(
             PluginEvents.SPOOL_SELECTED,
             PluginEvents.SPOOL_USAGE_COMMITTED,
             PluginEvents.SPOOL_USAGE_ERROR,
-        ]
+            PluginEvents.SPOOL_USAGE_COMMITTED_STARTUP,	
+        ]            
 
     def get_update_information(self):
         return {

--- a/octoprint_Spoolman/common/events.py
+++ b/octoprint_Spoolman/common/events.py
@@ -5,3 +5,4 @@ class PluginEvents():
 	SPOOL_SELECTED = "spool_selected"
 	SPOOL_USAGE_COMMITTED = "spool_usage_committed"
 	SPOOL_USAGE_ERROR = "spool_usage_error"
+	SPOOL_USAGE_COMMITTED_STARTUP	= "spool_usage_committed_startup" 

--- a/octoprint_Spoolman/common/settings.py
+++ b/octoprint_Spoolman/common/settings.py
@@ -8,3 +8,5 @@ class SettingsKeys():
 	SPOOLMAN_CERT_PEM_PATH = "spoolmanCertPemPath"
 	SELECTED_SPOOL_IDS = "selectedSpoolIds"
 	IS_PREPRINT_SPOOL_VERIFY_ENABLED = "isPreprintSpoolVerifyEnabled"
+	BACKUP_DATA = "backupData"
+	STATUS_BACKUP = "isstatusBackupEnabled"

--- a/octoprint_Spoolman/templates/Spoolman_settings.jinja2
+++ b/octoprint_Spoolman/templates/Spoolman_settings.jinja2
@@ -115,6 +115,25 @@
                         </div>
                     </div>
                 </div>
+                <div>
+                    <hr />
+                </div>
+                <div class="control-group">
+                    <label class="control-label" for="settings-spoolman-general-isstatusBackupEnabled">
+                        Enable filament usage backup
+                    </label>
+                    <div class="controls">
+                        <div>
+                            <input id="settings-spoolman-general-isstatusBackupEnabled" type="checkbox"
+                                class="text-left" data-bind="checked: pluginSettings.isstatusBackupEnabled">
+                        </div>
+                        <div style="margin-top: 0.25em">
+                            <small>
+                                Enabling the backup function allows you to store relevant information during the current printing process and generate an event with the print data. In particular, it records the grams of material used by the tools up to the moment a failure occurs. If this option is enabled and a failure occurs, the system will automatically update the data of the failed print when starting again, avoiding loss of information. For low-performance equipment, it is recommended to keep this option disabled.
+                            </small>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
A system for creating backups of used filament has been added. Filament usage information is stored continuously.

- This feature can be enabled and disabled from the settings.
- The "plugin_Spoolman_spool_usage_committed_startup" event has been added.
- 
