### PR TITLE
Add support for multi-colored spools in the color preview

### DIFF
--- a/octoprint_Spoolman/static/js/api/getSpoolmanSpools.js
+++ b/octoprint_Spoolman/static/js/api/getSpoolmanSpools.js
@@ -25,6 +25,8 @@
  * @property {string | undefined} filament.material
  * @property {string | undefined} filament.name
  * @property {string | undefined} filament.color_hex
+ * @property {string | undefined} filament.multi_color_hexes
+ * @property {string | undefined} filament.multi_color_direction
  * @property {FilamentVendor | undefined} filament.vendor
  */
 

--- a/octoprint_Spoolman/static/js/common/formatting.js
+++ b/octoprint_Spoolman/static/js/common/formatting.js
@@ -18,18 +18,12 @@ const toWeight = (weight, params) => {
 const toSpoolForDisplay = (spool, params) => {
     return {
         filament: {
-            color: {
-                cssProperty: (
-                    spool.filament.color_hex
-                        ? 'background-color'
-                        : 'background'
+            color: 
+                calculateColorCSS(
+                    spool.filament.color_hex,
+                    spool.filament.multi_color_direction,
+                    spool.filament.multi_color_hexes
                 ),
-                cssValue: (
-                    spool.filament.color_hex
-                        ? `#${spool.filament.color_hex}`
-                        : calculateGradient(spool.filament.multi_color_direction, spool.filament.multi_color_hexes)
-                ),
-            },
             name: (
                 spool.filament.name
                     ? {
@@ -92,18 +86,44 @@ const calculateWeight = (length, diameter, density) => {
 };
 
 /**
+ *  Generates a CSS property and value for the filament color
+ * @param {string | undefined} color_hex 
+ *  Hex color code for a single color filament or undefined
+ * @param {string | undefined} multi_color_direction 
+ *  Direction of the gradient for multi-color filaments or undefined
+ * @param {string | undefined} multi_color_hexes 
+ *  Hex color codes for multi-color filaments or undefined
+ * @returns Object {string, string}
+ *  cssProperty and cssValue for the filament color
+ */
+const calculateColorCSS = (color_hex, multi_color_direction, multi_color_hexes) => {
+    if (color_hex) {
+        return {cssProperty: 'background-color', cssValue: `#${color_hex}`};
+    }
+
+    let multiColorCSS = {
+        cssProperty: 'background',
+        cssValue: '',
+    };
+
+    if (!multi_color_direction || !multi_color_hexes) {
+        multiColorCSS.cssValue = 'linear-gradient(45deg, #000000 -25%, #ffffff)';
+        return multiColorCSS;
+    }
+
+    multiColorCSS.cssValue = calculateGradient(multi_color_direction, multi_color_hexes);
+    return multiColorCSS;
+}
+
+/**
  *  Builds a linear-gradient CSS property from the given colors and direction
- * @param {string | undefined} direction
+ * @param {string} direction
  *  Direction of the gradient
- * @param {string | undefined} colors
+ * @param {string} colors
  *  Comma-separated list of colors
  * @returns string
  */
 const calculateGradient = (direction, colors) => {
-    if (!direction || !colors) {
-        return 'linear-gradient(45deg, #000000 -25%, #ffffff)';
-    }
-
     let gradient = 'linear-gradient(';
 
     if (direction === 'coaxial') {

--- a/octoprint_Spoolman/static/js/common/formatting.js
+++ b/octoprint_Spoolman/static/js/common/formatting.js
@@ -27,7 +27,7 @@ const toSpoolForDisplay = (spool, params) => {
                 cssValue: (
                     spool.filament.color_hex
                         ? `#${spool.filament.color_hex}`
-                        : 'linear-gradient(45deg, #000000 -25%, #ffffff)'
+                        : calculateGradient(spool.filament.multi_color_direction, spool.filament.multi_color_hexes)
                 ),
             },
             name: (
@@ -90,3 +90,33 @@ const calculateWeight = (length, diameter, density) => {
 
     return volume * density;
 };
+
+/**
+ *  Builds a linear-gradient CSS property from the given colors and direction
+ * @param {string | undefined} direction
+ *  Direction of the gradient
+ * @param {string | undefined} colors
+ *  Comma-separated list of colors
+ * @returns string
+ */
+const calculateGradient = (direction, colors) => {
+    if (!direction || !colors) {
+        return 'linear-gradient(45deg, #000000 -25%, #ffffff)';
+    }
+
+    let gradient = 'linear-gradient(';
+
+    if (direction === 'coaxial') {
+        gradient += '90deg';
+    } else {
+        gradient += '180deg';
+    }
+
+    let colorsArray = colors.split(',');
+    for (let i = 0; i < colorsArray.length; i++) {
+        gradient += `, #${colorsArray[i]} ${(i / colorsArray.length) * 100}% ${((i+1) / colorsArray.length) * 100}%`;
+    }
+
+    gradient += ')';
+    return gradient;
+}

--- a/octoprint_Spoolman/static/js/common/formatting.js
+++ b/octoprint_Spoolman/static/js/common/formatting.js
@@ -18,7 +18,7 @@ const toWeight = (weight, params) => {
 const toSpoolForDisplay = (spool, params) => {
     return {
         filament: {
-            color: 
+            color:
                 calculateColorCSS(
                     spool.filament.color_hex,
                     spool.filament.multi_color_direction,
@@ -87,32 +87,37 @@ const calculateWeight = (length, diameter, density) => {
 
 /**
  *  Generates a CSS property and value for the filament color
- * @param {string | undefined} color_hex 
+ * @param {string | undefined} color_hex
  *  Hex color code for a single color filament or undefined
- * @param {string | undefined} multi_color_direction 
+ * @param {string | undefined} multi_color_direction
  *  Direction of the gradient for multi-color filaments or undefined
- * @param {string | undefined} multi_color_hexes 
+ * @param {string | undefined} multi_color_hexes
  *  Hex color codes for multi-color filaments or undefined
- * @returns Object {string, string}
+ * @returns {{
+*   cssProperty: string,
+*   cssValue: string,
+*  }}
  *  cssProperty and cssValue for the filament color
  */
 const calculateColorCSS = (color_hex, multi_color_direction, multi_color_hexes) => {
     if (color_hex) {
-        return {cssProperty: 'background-color', cssValue: `#${color_hex}`};
+        return {
+            cssProperty: 'background-color',
+            cssValue: `#${color_hex}`,
+        };
     }
-
-    let multiColorCSS = {
-        cssProperty: 'background',
-        cssValue: '',
-    };
 
     if (!multi_color_direction || !multi_color_hexes) {
-        multiColorCSS.cssValue = 'linear-gradient(45deg, #000000 -25%, #ffffff)';
-        return multiColorCSS;
+        return {
+            cssProperty: 'background',
+            cssValue: 'linear-gradient(45deg, #000000 -25%, #ffffff)',
+        };
     }
 
-    multiColorCSS.cssValue = calculateGradient(multi_color_direction, multi_color_hexes);
-    return multiColorCSS;
+    return {
+        cssProperty: 'background',
+        cssValue: calculateGradient(multi_color_direction, multi_color_hexes),
+    };
 }
 
 /**


### PR DESCRIPTION
## Description
Multi-colored spools will now properly display their gradient, replacing the default gradient from before and matching how they appear in the Spoolman interface.

## Related Issue / Discussion
Closes #57 

## How has this been tested?
Tested with several different filaments using up to 5 colors in both coaxial and longitudinal orientations. Past this point the gradient can become harder to parse visually.

## Screenshots (if appropriate):
![Spoolman](https://github.com/user-attachments/assets/3c28a271-8e8d-437a-8b7b-10132f7f4d01)
![Sidebar](https://github.com/user-attachments/assets/52788a01-0590-4bb5-89e5-7c91e604d673)
![Select Spool Modal](https://github.com/user-attachments/assets/e40e8b9c-8582-454a-9c74-6f8202427e6c)

## Types of changes
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have verified that my changes do not break the overall functionality of the plugin.
