### PR TITLE
Add Lot No to Select Spool Modal

### DIFF
--- a/octoprint_Spoolman/SpoolmanPlugin.py
+++ b/octoprint_Spoolman/SpoolmanPlugin.py
@@ -126,6 +126,7 @@ class SpoolmanPlugin(
             SettingsKeys.SPOOLMAN_CERT_PEM_PATH: "",
             SettingsKeys.SELECTED_SPOOL_IDS: {},
             SettingsKeys.IS_PREPRINT_SPOOL_VERIFY_ENABLED: True,
+            SettingsKeys.SHOW_LOT_NUMBER_COLUMN_IN_SPOOL_SELECT_MODAL: False,
         }
 
         return settings

--- a/octoprint_Spoolman/common/settings.py
+++ b/octoprint_Spoolman/common/settings.py
@@ -8,3 +8,4 @@ class SettingsKeys():
 	SPOOLMAN_CERT_PEM_PATH = "spoolmanCertPemPath"
 	SELECTED_SPOOL_IDS = "selectedSpoolIds"
 	IS_PREPRINT_SPOOL_VERIFY_ENABLED = "isPreprintSpoolVerifyEnabled"
+	SHOW_LOT_NUMBER_COLUMN_IN_SPOOL_SELECT_MODAL = "showLotNumberColumnInSpoolSelectModal"

--- a/octoprint_Spoolman/static/js/Spoolman_modal_selectSpool.js
+++ b/octoprint_Spoolman/static/js/Spoolman_modal_selectSpool.js
@@ -89,6 +89,8 @@ $(() => {
 
             self.templateData.spoolmanUrl(getPluginSettings().spoolmanUrl());
 
+            self.templateData.tableAttributeVisibility.lot(Boolean(getPluginSettings().showLotNumberColumnInSpoolSelectModal()));
+
             refreshModalLayout();
         };
 
@@ -150,7 +152,7 @@ $(() => {
                 id: true,
                 spoolName: true,
                 material: true,
-                lot: true,
+                lot: ko.observable(Boolean(getPluginSettings().showLotNumberColumnInSpoolSelectModal())),
                 weight: true,
             },
             tableItemsOnCurrentPage: ko.observable([]),

--- a/octoprint_Spoolman/static/js/Spoolman_modal_selectSpool.js
+++ b/octoprint_Spoolman/static/js/Spoolman_modal_selectSpool.js
@@ -150,6 +150,7 @@ $(() => {
                 id: true,
                 spoolName: true,
                 material: true,
+                lot: true,
                 weight: true,
             },
             tableItemsOnCurrentPage: ko.observable([]),

--- a/octoprint_Spoolman/static/js/api/getSpoolmanSpools.js
+++ b/octoprint_Spoolman/static/js/api/getSpoolmanSpools.js
@@ -15,6 +15,7 @@
  * @property {number} used_weight
  * @property {number | undefined} remaining_length
  * @property {number | undefined} remaining_weight
+ * @property {string | undefined} lot_nr
  * @property {Object} filament
  * @property {number} filament.id
  * @property {string} filament.registered

--- a/octoprint_Spoolman/static/js/common/formatting.js
+++ b/octoprint_Spoolman/static/js/common/formatting.js
@@ -72,6 +72,14 @@ const toSpoolForDisplay = (spool, params) => {
                     displayValue: "Unavailable",
                 }
         ),
+        lot: (
+            spool.lot_nr
+                ? {
+                    displayValue: spool.lot_nr,
+                } : {
+                    displayValue: "",
+                }
+        ),
     };
 };
 

--- a/octoprint_Spoolman/templates/Spoolman_settings.jinja2
+++ b/octoprint_Spoolman/templates/Spoolman_settings.jinja2
@@ -22,6 +22,14 @@
                     General
                 </a>
             </li>
+            <li>
+                <a
+                    href="#tab-spoolman-Display-Settings"
+                    data-toggle="tab"
+                >
+                    Display Settings
+                </a>
+            </li>
         </ul>
 
         <div class="tab-content">
@@ -111,6 +119,35 @@
                         <div style="margin-top: 0.25em">
                             <small>
                                 Spools verification displays a modal after clicking the 'Print' button, which presents all necessary info & warnings before the actual print job starts. It allows the user to either confirm (and start the print) or cancel the job. Verification consists of: checking remaining filament, checking spool selection, detecting tools count mismatch (multi-tool printers).
+                            </small>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <!-- Tab: Display Settings -->
+            <div
+                id="tab-spoolman-Display-Settings"
+                class="tab-pane"
+            >
+                <div class="control-group">
+                    <label
+                        class="control-label"
+                        for="settings-spoolman-display-settings-showLotNumberColumnInSpoolSelectModal"
+                    >
+                        Show Lot Number column in Spool Select Modal
+                    </label>
+                    <div class="controls">
+                        <div>
+                            <input
+                                id="settings-spoolman-display-settings-showLotNumberColumnInSpoolSelectModal"
+                                type="checkbox"
+                                class="text-left"
+                                data-bind="checked: pluginSettings.showLotNumberColumnInSpoolSelectModal"
+                            >
+                        </div>
+                        <div style="margin-top: 0.25em">
+                            <small>
+                                If enabled, the "Lot Number" column will be displayed in the Spool Select Modal. The column will show the lot number of the spool, if available.
                             </small>
                         </div>
                     </div>

--- a/octoprint_Spoolman/templates/Spoolman_sidebar.jinja2
+++ b/octoprint_Spoolman/templates/Spoolman_sidebar.jinja2
@@ -113,7 +113,10 @@
                             </div>
                         <!-- /ko -->
 
-                        <div>
+                        <div style="text-align: center;">
+                            <span
+                                style="margin-right: 5px;" 
+                                data-bind="text: $data.spoolId, attr: { title: $data.spoolId }"></span>
                             <span
                                 class="color-preview"
                                 style="flex-shrink: 0;"
@@ -127,7 +130,10 @@
                             <span>[<span data-bind="
                                 text: $data.spoolDisplayData.filament.material.displayShort,
                                 attr: { title: $data.spoolDisplayData.filament.material.displayValue }
-                            "></span>]</span>
+                            "></span>] <span data-bind="
+                                text: $data.spoolDisplayData.lot.displayValue,
+                                attr: { title: $data.spoolDisplayData.lot.displayValue }
+                            "></span></span>
                             <span data-bind="
                                 text: $data.spoolDisplayData.filament.name.displayValue,
                                 attr: { title: $data.spoolDisplayData.filament.name.displayValue }

--- a/octoprint_Spoolman/templates/Spoolman_sidebar.jinja2
+++ b/octoprint_Spoolman/templates/Spoolman_sidebar.jinja2
@@ -113,10 +113,7 @@
                             </div>
                         <!-- /ko -->
 
-                        <div style="text-align: center;">
-                            <span
-                                style="margin-right: 5px;" 
-                                data-bind="text: $data.spoolId, attr: { title: $data.spoolId }"></span>
+                        <div>
                             <span
                                 class="color-preview"
                                 style="flex-shrink: 0;"
@@ -130,10 +127,7 @@
                             <span>[<span data-bind="
                                 text: $data.spoolDisplayData.filament.material.displayShort,
                                 attr: { title: $data.spoolDisplayData.filament.material.displayValue }
-                            "></span>] <span data-bind="
-                                text: $data.spoolDisplayData.lot.displayValue,
-                                attr: { title: $data.spoolDisplayData.lot.displayValue }
-                            "></span></span>
+                            "></span>]</span>
                             <span data-bind="
                                 text: $data.spoolDisplayData.filament.name.displayValue,
                                 attr: { title: $data.spoolDisplayData.filament.name.displayValue }

--- a/octoprint_Spoolman/templates/Spoolman_sidebar_modal_selectspool.jinja2
+++ b/octoprint_Spoolman/templates/Spoolman_sidebar_modal_selectspool.jinja2
@@ -106,16 +106,22 @@
                                 ID
                             </th>
                             <th
-                                style="width: 55%"
+                                style="width: 50%"
                                 data-bind="visible: templateData.tableAttributeVisibility.spoolName"
                             >
                                 Name
                             </th>
                             <th
-                                style="width: 20%"
+                                style="width: 15%"
                                 data-bind="visible: templateData.tableAttributeVisibility.material"
                             >
                                 Material
+                            </th>
+                            <th
+                                style="width: 15%"
+                                data-bind="visible: templateData.tableAttributeVisibility.lot"
+                            >
+                                Lot #
                             </th>
                             <th
                                 style="text-align: center; width: 15%;"
@@ -177,6 +183,9 @@
                                 </td>
                                 <td data-bind="visible: $component.templateData.tableAttributeVisibility.material">
                                     <span data-bind="text: $data.displayData.filament.material.displayValue, attr: { title: $data.displayData.filament.material.displayValue }"></span>
+                                </td>
+                                <td data-bind="visible: $component.templateData.tableAttributeVisibility.lot" style="overflow-wrap: break-word;">
+                                    <span data-bind="text: $data.displayData.lot.displayValue, attr: { title: $data.displayData.lot.displayValue }"></span>
                                 </td>
                                 <td
                                     data-bind="visible: $component.templateData.tableAttributeVisibility.weight" style="text-align: right;"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
This PR adds ~the Spool ID and the Lot Number to the Sidebar and~ adds the Lot Number to the Select Spool Modal

Edit (by @mdziekon): Sidebar modifications moved out of this PR.

## Related Issue / Discussion
Fixes #52 

## How has this been tested?
I tested with lot numbers between 10 and 64 characters (the maximum allowed by Spoolman)

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/fd49df82-10ca-4b15-a99d-1c72f4df8aa2)
![image](https://github.com/user-attachments/assets/7ec0e061-01d4-4677-9732-54231f1836b4)
![image](https://github.com/user-attachments/assets/76c1a032-ac63-4270-8854-6035a54badd3)


## Types of changes
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have verified that my changes do not break the overall functionality of the plugin.
