### PR TITLE
Lot Number and Spool ID in Sidebar

### DIFF
--- a/octoprint_Spoolman/SpoolmanPlugin.py
+++ b/octoprint_Spoolman/SpoolmanPlugin.py
@@ -127,6 +127,8 @@ class SpoolmanPlugin(
             SettingsKeys.SELECTED_SPOOL_IDS: {},
             SettingsKeys.IS_PREPRINT_SPOOL_VERIFY_ENABLED: True,
             SettingsKeys.SHOW_LOT_NUMBER_COLUMN_IN_SPOOL_SELECT_MODAL: False,
+            SettingsKeys.SHOW_LOT_NUMBER_IN_SIDE_BAR: False,
+            SettingsKeys.SHOW_SPOOL_ID_IN_SIDE_BAR: False,
         }
 
         return settings

--- a/octoprint_Spoolman/common/settings.py
+++ b/octoprint_Spoolman/common/settings.py
@@ -9,3 +9,5 @@ class SettingsKeys():
 	SELECTED_SPOOL_IDS = "selectedSpoolIds"
 	IS_PREPRINT_SPOOL_VERIFY_ENABLED = "isPreprintSpoolVerifyEnabled"
 	SHOW_LOT_NUMBER_COLUMN_IN_SPOOL_SELECT_MODAL = "showLotNumberColumnInSpoolSelectModal"
+	SHOW_LOT_NUMBER_IN_SIDE_BAR = "showLotNumberInSidebar"
+	SHOW_SPOOL_ID_IN_SIDE_BAR = "showSpoolIdInSidebar"

--- a/octoprint_Spoolman/static/js/Spoolman_sidebar.js
+++ b/octoprint_Spoolman/static/js/Spoolman_sidebar.js
@@ -93,6 +93,9 @@ $(() => {
             self.templateData.selectedSpoolsByToolIdx.valueHasMutated();
 
             self.templateData.spoolmanUrl(getPluginSettings().spoolmanUrl());
+
+            self.templateData.optionalFieldVisibility.lotNumber(Boolean(getPluginSettings().showLotNumberInSidebar()));
+            self.templateData.optionalFieldVisibility.spoolID(Boolean(getPluginSettings().showSpoolIdInSidebar()));
         };
 
         /**
@@ -215,6 +218,11 @@ $(() => {
             spoolmanUrl: ko.observable(undefined),
 
             settingsViewModel: ko.observable(undefined),
+
+            optionalFieldVisibility: {
+                lotNumber: ko.observable(false),
+                spoolID: ko.observable(false),
+            },
 
             modals: {
                 selectSpool: {

--- a/octoprint_Spoolman/static/js/Spoolman_sidebar.js
+++ b/octoprint_Spoolman/static/js/Spoolman_sidebar.js
@@ -7,6 +7,8 @@ $(() => {
 
         const previousSettings = {
             spoolmanUrl: undefined,
+            showLotNumberInSidebar: undefined,
+            showSpoolIdInSidebar: undefined,
         };
 
         self.settingsViewModel = params[0];
@@ -444,15 +446,24 @@ $(() => {
         self.onSettingsHidden = () => {
             const newSettings = {
                 spoolmanUrl: getPluginSettings().spoolmanUrl(),
+                showLotNumberInSidebar: getPluginSettings().showLotNumberInSidebar(),
+                showSpoolIdInSidebar: getPluginSettings().showSpoolIdInSidebar(),
             };
 
-            if (previousSettings.spoolmanUrl === newSettings.spoolmanUrl) {
-                return;
+            if (previousSettings.spoolmanUrl !== newSettings.spoolmanUrl) {
+                previousSettings.spoolmanUrl = newSettings.spoolmanUrl;
+                pluginSpoolmanApi.getSpoolmanSpools.invalidate();
             }
 
-            previousSettings.spoolmanUrl = newSettings.spoolmanUrl;
+            if (
+                previousSettings.showLotNumberInSidebar !== newSettings.showLotNumberInSidebar ||
+                previousSettings.showSpoolIdInSidebar !== newSettings.showSpoolIdInSidebar
+            ) {
+                previousSettings.showLotNumberInSidebar = newSettings.showLotNumberInSidebar;
+                previousSettings.showSpoolIdInSidebar = newSettings.showSpoolIdInSidebar;
 
-            pluginSpoolmanApi.getSpoolmanSpools.invalidate();
+                updateSelectedSpools();
+            }
         };
     };
 

--- a/octoprint_Spoolman/static/js/common/formatting.js
+++ b/octoprint_Spoolman/static/js/common/formatting.js
@@ -153,3 +153,16 @@ const calculateGradient = (direction, colors) => {
     gradient += ')';
     return gradient;
 }
+
+/**
+ * @param {string} lot_nr
+ *  Lot number
+ * @returns string
+ */
+const calculateShortLot = (lot_nr) => {
+    if (lot_nr.length <= 9) {
+        return lot_nr;
+    }
+
+    return `${lot_nr.substring(0, 3)}...${lot_nr.substring(lot_nr.length - 3)}`;
+}

--- a/octoprint_Spoolman/static/js/common/formatting.js
+++ b/octoprint_Spoolman/static/js/common/formatting.js
@@ -72,8 +72,8 @@ const toSpoolForDisplay = (spool, params) => {
                     displayShort: calculateShortLot(spool.lot_nr),
                     displayValue: spool.lot_nr,
                 } : {
-                    displayShort: "",
-                    displayValue: "",
+                    displayShort: "N/A",
+                    displayValue: "N/A",
                 }
         ),
     };

--- a/octoprint_Spoolman/static/js/common/formatting.js
+++ b/octoprint_Spoolman/static/js/common/formatting.js
@@ -69,8 +69,10 @@ const toSpoolForDisplay = (spool, params) => {
         lot: (
             spool.lot_nr
                 ? {
+                    displayShort: calculateShortLot(spool.lot_nr),
                     displayValue: spool.lot_nr,
                 } : {
+                    displayShort: "",
                     displayValue: "",
                 }
         ),

--- a/octoprint_Spoolman/templates/Spoolman_settings.jinja2
+++ b/octoprint_Spoolman/templates/Spoolman_settings.jinja2
@@ -152,6 +152,53 @@
                         </div>
                     </div>
                 </div>
+                <hr>
+                <div class="control-group">
+                    <label
+                        class="control-label"
+                        for="settings-spoolman-display-settings-showLotNumberInSidebar"
+                    >
+                        Show Lot Number in Sidebar
+                    </label>
+                    <div class="controls">
+                        <div>
+                            <input
+                                id="settings-spoolman-display-settings-showLotNumberInSidebar"
+                                type="checkbox"
+                                class="text-left"
+                                data-bind="checked: pluginSettings.showLotNumberInSidebar"
+                            >
+                        </div>
+                        <div style="margin-top: 0.25em">
+                            <small>
+                                If enabled, a shortened version (maximum of 9 characters) of the "Lot Number" will be shown in the sidebar when a spool is assigned to a tool. The full lot number is visible if you hover over the shortened version.
+                            </small>
+                        </div>
+                    </div>
+                </div>
+                <div class="control-group">
+                    <label
+                        class="control-label"
+                        for="settings-spoolman-display-settings-showSpoolIdInSidebar"
+                    >
+                        Show Spool ID in Sidebar
+                    </label>
+                    <div class="controls">
+                        <div>
+                            <input
+                                id="settings-spoolman-display-settings-showSpoolIdInSidebar"
+                                type="checkbox"
+                                class="text-left"
+                                data-bind="checked: pluginSettings.showSpoolIdInSidebar"
+                            >
+                        </div>
+                        <div style="margin-top: 0.25em">
+                            <small>
+                                If enabled, the ID of the selected spool will be shown after the amount of filament remaining, but before the lot number (if enabled and available).
+                            </small>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/octoprint_Spoolman/templates/Spoolman_settings.jinja2
+++ b/octoprint_Spoolman/templates/Spoolman_settings.jinja2
@@ -194,7 +194,7 @@
                         </div>
                         <div style="margin-top: 0.25em">
                             <small>
-                                If enabled, the ID of the selected spool will be shown after the amount of filament remaining, but before the lot number (if enabled and available).
+                                If enabled, the ID of the selected spool will be shown in the sidebar info.
                             </small>
                         </div>
                     </div>

--- a/octoprint_Spoolman/templates/Spoolman_sidebar.jinja2
+++ b/octoprint_Spoolman/templates/Spoolman_sidebar.jinja2
@@ -141,11 +141,11 @@
                                 attr: {title: 'Remaining weight'},
                                 class: ($data.spoolDisplayData.remaining_weight.isValid) ? '' : 'text-error'
                             "></span></span>
-                            <span><span data-bind="
+                            <span data-bind="visible: $parent.templateData.optionalFieldVisibility.lotNumber"><span data-bind="
                                 text: $data.spoolId,
                                 attr: { title: 'ID: ' + $data.spoolId }    
                             "></span></span>
-                            <span><span data-bind="
+                            <span data-bind="visible: $parent.templateData.optionalFieldVisibility.spoolID"><span data-bind="
                                 text: $data.spoolDisplayData.lot.displayShort,
                                 attr: { title: 'Lot #: ' + $data.spoolDisplayData.lot.displayValue }
                             "></span></span>

--- a/octoprint_Spoolman/templates/Spoolman_sidebar.jinja2
+++ b/octoprint_Spoolman/templates/Spoolman_sidebar.jinja2
@@ -141,6 +141,14 @@
                                 attr: {title: 'Remaining weight'},
                                 class: ($data.spoolDisplayData.remaining_weight.isValid) ? '' : 'text-error'
                             "></span></span>
+                            <span><span data-bind="
+                                text: $data.spoolId,
+                                attr: { title: 'ID: ' + $data.spoolId }    
+                            "></span></span>
+                            <span><span data-bind="
+                                text: $data.spoolDisplayData.lot.displayShort,
+                                attr: { title: 'Lot #: ' + $data.spoolDisplayData.lot.displayValue }
+                            "></span></span>
                         </div>
                     </div>
                     <div style="display: flex; flex-shrink: 0;">

--- a/octoprint_Spoolman/templates/Spoolman_sidebar.jinja2
+++ b/octoprint_Spoolman/templates/Spoolman_sidebar.jinja2
@@ -141,11 +141,11 @@
                                 attr: {title: 'Remaining weight'},
                                 class: ($data.spoolDisplayData.remaining_weight.isValid) ? '' : 'text-error'
                             "></span></span>
-                            <span data-bind="visible: $parent.templateData.optionalFieldVisibility.lotNumber"><span data-bind="
+                            <span data-bind="visible: $parent.templateData.optionalFieldVisibility.spoolID"><span data-bind="
                                 text: $data.spoolId,
                                 attr: { title: 'ID: ' + $data.spoolId }    
                             "></span></span>
-                            <span data-bind="visible: $parent.templateData.optionalFieldVisibility.spoolID"><span data-bind="
+                            <span data-bind="visible: $parent.templateData.optionalFieldVisibility.lotNumber"><span data-bind="
                                 text: $data.spoolDisplayData.lot.displayShort,
                                 attr: { title: 'Lot #: ' + $data.spoolDisplayData.lot.displayValue }
                             "></span></span>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
This has not gotten any less tricky than when I approached it previously. Per that discussion I moved both the Spool ID and Lot Number to the end of the section (after the remaining weight). While I think this is the correct location for the lot number, with the spool id here as well it seems like a jumbled mess. I attempted to compensate for this with descriptive hover text, but it still seems very messy to me. I think that, even if the spool id does not go in the left "column" it should go before the material type, but even that didn't look great in testing.

## Related Issue / Discussion
This is a continuation of #64 to try and bring some more information to the sidebar as well 

## How has this been tested?
Tested with lot numbers of length 4-64 and spool ids up to 3 digits

## Screenshots (if appropriate):
Default Settings:
![image](https://github.com/user-attachments/assets/33b0d6cc-5799-4c51-8a13-9c5b4d4453eb)
Lot hover text on shortened lot number
![image](https://github.com/user-attachments/assets/18374dba-fb63-4ae1-8901-9ba22208467d)
ID hover text
![image](https://github.com/user-attachments/assets/968d73ea-8350-49f3-9e46-ccc94d665443)
Short lot number (not long enough to be shortened)
![image](https://github.com/user-attachments/assets/57fad97f-89f3-4198-8a9d-85420b338f26)
No Lot Number
![image](https://github.com/user-attachments/assets/1688b34d-f296-4d10-8ee2-b8f53738dc92)

## Types of changes
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have verified that my changes do not break the overall functionality of the plugin.
