### PR TITLE
Add Icons to Filament Check

### DIFF
--- a/octoprint_Spoolman/static/js/Spoolman_sidebar.js
+++ b/octoprint_Spoolman/static/js/Spoolman_sidebar.js
@@ -315,7 +315,7 @@ $(() => {
             });
 
             const template = document.createElement('template');
-            template.innerHTML = `<span><span data-bind="text: _.sprintf(gettext('Filament (%(name)s)'), { name: name() }), attr: {title: _.sprintf(gettext('Filament usage for %(name)s'), {name: name()})}"></span>: <strong data-bind="class: $root.formatEnhancedFilamentColor(data()), text: $root.formatEnhancedFilament(data())"></strong><br></span>`;
+            template.innerHTML = `<span><span data-bind="text: _.sprintf(gettext('Filament (%(name)s)'), { name: name() }), attr: {title: _.sprintf(gettext('Filament usage for %(name)s'), {name: name()})}"></span>: <span data-bind="class: $root.formatEnhancedFilamentColor(data())"><span data-bind="class: $root.formatEnhancedFilamentIcon(data())"></span> <strong data-bind="text: $root.formatEnhancedFilament(data())"></strong></span><br></span>`;
 
             const nodeIteratorLoopStart = document.createComment(' ko foreach: enhancedFilaments ');
             const nodeIteratorLoopElement = template.content.firstChild?.cloneNode(true);

--- a/octoprint_Spoolman/static/js/Spoolman_sidebar.js
+++ b/octoprint_Spoolman/static/js/Spoolman_sidebar.js
@@ -269,6 +269,17 @@ $(() => {
 
                 return filament.isEnoughFilament ? 'text-success' : 'text-error';
             };
+            printerStateViewModel.formatEnhancedFilamentIcon = (filament) => {
+                if (
+                    !filament ||
+                    filament.modelWeight === undefined ||
+                    filament.isEnoughFilament === undefined
+                ) {
+                    return '';
+                }
+
+                return filament.isEnoughFilament ? 'fa fa-circle-check' : 'fa fa-warning';
+            };
 
             printerStateViewModel.enhancedFilaments = ko.computed(function () {
                 const modelFilaments = self.printerStateViewModel.filament();


### PR DESCRIPTION
## Description
Adds a `fa-warning` when the selected spool has insufficient filament and a `fa-circle-check` when the spool has sufficient filament for the selected print.

## Related Issue / Discussion
#65 

## How has this been tested?
Tested with a print requiring ≈500g of filament using spools that have 1g and 1000g remaining, also tested with the PrintTimeGenius plugin (adds cm^3 value to filament line in state view)

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/964f0fa5-1aa3-4501-8159-ce517dccfc66)
![image](https://github.com/user-attachments/assets/97aad91e-2876-4184-bfa0-605352c501a2)

## Types of changes
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have verified that my changes do not break the overall functionality of the plugin.
