### PR TITLE
feat: Improve info formatting in the Sidebar (GH-52)

### DIFF
--- a/octoprint_Spoolman/static/css/Spoolman.css
+++ b/octoprint_Spoolman/static/css/Spoolman.css
@@ -15,6 +15,13 @@
     white-space: pre-wrap;
     overflow-wrap: anywhere;
 }
+.sidebar-spool-info {
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+
+    overflow-wrap: anywhere;
+}
 
 .tool-row {
     display: flex;

--- a/octoprint_Spoolman/static/js/common/formatting.js
+++ b/octoprint_Spoolman/static/js/common/formatting.js
@@ -2,11 +2,12 @@
 /**
  * @param {number} weight
  * @param {{
-*  constants: Record<string, unknown>
+*  constants: Record<string, unknown>;
+*  precision?: number
 * }} params
 */
 const toWeight = (weight, params) => {
-    return `${weight.toFixed(1)}${params.constants['weight_unit']}`;
+    return `${weight.toFixed(params.precision ?? 1)}${params.constants['weight_unit']}`;
 };
 
 /**
@@ -52,6 +53,12 @@ const toSpoolForDisplay = (spool, params) => {
                         }
                 ),
             },
+        },
+        initial_weight: {
+            displayValue: toWeight((spool.filament.weight ?? 0), {
+                ...params,
+                precision: 0,
+            })
         },
         used_weight: {
             displayValue: spool.used_weight.toFixed(1),

--- a/octoprint_Spoolman/templates/Spoolman_sidebar.jinja2
+++ b/octoprint_Spoolman/templates/Spoolman_sidebar.jinja2
@@ -68,19 +68,26 @@
             <div class="tool-row">
                 <!-- ko ifnot: $data.spoolId && $data.spoolData && $data.spoolDisplayData -->
                     <div style="display: flex;">
-                        <!-- ko if: $parent.templateData.selectedSpoolsByToolIdx().length > 1 -->
-                            <div class="tool-idx" style="margin-right: 0.25em;">
-                                <b>Tool #<span data-bind="text: $index()"></span>:</b>
+                        <div>
+                            <span
+                                class="color-preview"
+                                style="flex-shrink: 0;"
+                            ></span>
+                        </div>
+                        <div class="sidebar-spool-info">
+                            <!-- ko if: $parent.templateData.selectedSpoolsByToolIdx().length > 1 -->
+                                <div>
+                                    <b>Tool #<span data-bind="text: $index()"></span>:</b>
+                                </div>
+                            <!-- /ko -->
+                            <div>
+                                <!-- ko if: $data.spoolId -->
+                                    <i class="text-error">Unknown spool selected</i>
+                                <!-- /ko -->
+                                <!-- ko ifnot: $data.spoolId -->
+                                    <i class="muted">No spool selected</i>
+                                <!-- /ko -->
                             </div>
-                        <!-- /ko -->
-
-                        <div class="spool-label">
-                            <!-- ko if: $data.spoolId -->
-                                <i class="text-error">Unknown spool selected</i>
-                            <!-- /ko -->
-                            <!-- ko ifnot: $data.spoolId -->
-                                <i class="muted">No spool selected</i>
-                            <!-- /ko -->
                         </div>
                     </div>
                     <div style="display: flex; flex-shrink: 0;">
@@ -107,48 +114,69 @@
 
                 <!-- ko if: $data.spoolData && $data.spoolDisplayData -->
                     <div style="display: flex;">
-                        <!-- ko if: $parent.templateData.selectedSpoolsByToolIdx().length > 1 -->
-                            <div class="tool-idx" style="margin-right: 0.25em;">
-                                <b>Tool #<span data-bind="text: $index()"></span>:</b>
-                            </div>
-                        <!-- /ko -->
-
                         <div>
                             <span
                                 class="color-preview"
                                 style="flex-shrink: 0;"
                                 data-bind="
                                     style: { [$data.spoolDisplayData.filament.color.cssProperty]: $data.spoolDisplayData.filament.color.cssValue },
-                                    attr: { title: $data.spoolDisplayData.filament.name.displayValue }
+                                    attr: { title: 'Name: ' + $data.spoolDisplayData.filament.name.displayValue }
                                 "
                             ></span>
                         </div>
-                        <div class="spool-label">
-                            <span>[<span data-bind="
-                                text: $data.spoolDisplayData.filament.material.displayShort,
-                                attr: { title: $data.spoolDisplayData.filament.material.displayValue }
-                            "></span>]</span>
-                            <span data-bind="
-                                text: $data.spoolDisplayData.filament.name.displayValue,
-                                attr: { title: $data.spoolDisplayData.filament.name.displayValue }
-                            "></span>
-                            <i>(<span data-bind="
-                                text: $data.spoolDisplayData.filament.vendor.name.displayValue,
-                                attr: { title: $data.spoolDisplayData.filament.vendor.name.displayValue }
-                            "></span>)</i>
-                            <span><span data-bind="
-                                text: $data.spoolDisplayData.remaining_weight.displayValue,
-                                attr: {title: 'Remaining weight'},
-                                class: ($data.spoolDisplayData.remaining_weight.isValid) ? '' : 'text-error'
-                            "></span></span>
-                            <span data-bind="visible: $parent.templateData.optionalFieldVisibility.spoolID"><span data-bind="
-                                text: $data.spoolId,
-                                attr: { title: 'ID: ' + $data.spoolId }    
-                            "></span></span>
-                            <span data-bind="visible: $parent.templateData.optionalFieldVisibility.lotNumber"><span data-bind="
-                                text: $data.spoolDisplayData.lot.displayShort,
-                                attr: { title: 'Lot #: ' + $data.spoolDisplayData.lot.displayValue }
-                            "></span></span>
+                        <div class="sidebar-spool-info">
+                            <!-- ko if: $parent.templateData.selectedSpoolsByToolIdx().length > 1 -->
+                                <div>
+                                    <b>Tool #<span data-bind="text: $index()"></span>:</b>
+                                </div>
+                            <!-- /ko -->
+                            <div>
+                                <span>[<span data-bind="
+                                    text: $data.spoolDisplayData.filament.material.displayShort,
+                                    attr: { title: 'Material: ' + $data.spoolDisplayData.filament.material.displayValue }
+                                "></span>]</span>
+                                <span data-bind="
+                                    text: $data.spoolDisplayData.filament.name.displayValue,
+                                    attr: { title: 'Name: ' + $data.spoolDisplayData.filament.name.displayValue }
+                                "></span>
+                                <i>(<span data-bind="
+                                    text: $data.spoolDisplayData.filament.vendor.name.displayValue,
+                                    attr: { title: 'Manufacturer: ' + $data.spoolDisplayData.filament.vendor.name.displayValue }
+                                "></span>)</i>
+                            </div>
+                            <div>
+                                <span>
+                                    <span data-bind="
+                                        text: $data.spoolDisplayData.remaining_weight.displayValue,
+                                        attr: {title: 'Remaining weight: ' + $data.spoolDisplayData.remaining_weight.displayValue },
+                                        class: ($data.spoolDisplayData.remaining_weight.isValid) ? '' : 'text-error'
+                                    "></span>
+                                </span>
+                                <span data-bind="visible: $data.spoolDisplayData.remaining_weight.isValid">
+                                    / <span data-bind="
+                                        text: $data.spoolDisplayData.initial_weight.displayValue,
+                                        attr: {title: 'Initial weight: ' + $data.spoolDisplayData.initial_weight.displayValue},
+                                    "></span>
+                                </span>
+                            </div>
+                            <div
+                                class="muted"
+                                data-bind="visible: ($parent.templateData.optionalFieldVisibility.spoolID() || $parent.templateData.optionalFieldVisibility.lotNumber())"
+                            >
+                                <span data-bind="visible: $parent.templateData.optionalFieldVisibility.spoolID">
+                                    <span data-bind="attr: { title: 'ID: ' + $data.spoolId }">
+                                        #<span data-bind="text: $data.spoolId"></span>
+                                    </span>
+                                </span>
+                                <span
+                                    data-bind="visible: ($parent.templateData.optionalFieldVisibility.spoolID() && $parent.templateData.optionalFieldVisibility.lotNumber())"
+                                >|</span>
+                                <span data-bind="visible: $parent.templateData.optionalFieldVisibility.lotNumber">
+                                    <span data-bind="attr: { title: 'Lot #: ' + $data.spoolDisplayData.lot.displayValue }">
+                                        Lot <span data-bind="text: $data.spoolDisplayData.lot.displayShort"></span>
+                                    </span>
+                                </span>
+                            </div>
                         </div>
                     </div>
                     <div style="display: flex; flex-shrink: 0;">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description

Continuation of [Lot Number and Spool ID in Sidebar](https://github.com/mdziekon/octoprint-spoolman/pull/68).

Sidebar's spool ID & lot number display got a bit crowded, therefore some reformatting was necessary.

Changelog:
- Tool no. is now in the same column as the rest of the textual data
- Spool weight is now displayed under filament's name & manufacturer
- Spool ID & Lot no (if displayed) are now rendered in the third line, under weight
- Added "initial weight" of the spool to the weight line display

## Related Issue / Discussion

Continuation of: https://github.com/mdziekon/octoprint-spoolman/pull/68
Related issue: https://github.com/mdziekon/octoprint-spoolman/issues/52

## How has this been tested?

See screenshots below

## Screenshots (if appropriate):

Single tool, ID & lot no displayed

![obraz](https://github.com/user-attachments/assets/0424cef3-3d6a-4411-a3f3-ecd06ceed235)

Multi tool, ID & lot no displayed

![obraz](https://github.com/user-attachments/assets/f24c998a-4808-4706-b9fa-b75ddb073fe7)

Single tool, only lot no displayed

![obraz](https://github.com/user-attachments/assets/70581a6b-386a-48dc-8d92-1840c57d72a9)

Single tool, only spool ID displayed

![obraz](https://github.com/user-attachments/assets/270e96b4-2e7e-4db2-9b0a-cf4cbfb4bc27)

Single tool, no spool ID & lot no displayed

![obraz](https://github.com/user-attachments/assets/bdccef21-e92e-4906-ac77-cbb79cdf7c63)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have verified that my changes do not break the overall functionality of the plugin.
