### PR TITLE
Webhook implemented, to set Spool from FilaMan or others

### DIFF
--- a/octoprint_Spoolman/SpoolmanPlugin.py
+++ b/octoprint_Spoolman/SpoolmanPlugin.py
@@ -16,14 +16,19 @@ class SpoolmanPlugin(
     octoprint.plugin.TemplatePlugin,
     octoprint.plugin.EventHandlerPlugin,
     octoprint.plugin.BlueprintPlugin,
-    PrinterUtils,
-    PrinterHandler,
-    PluginAPI
+    PluginAPI,
+    PrinterHandler
 ):
     _isInitialized = False
 
     def initialize(self):
         self._isInitialized = True
+        self._printer_utils = PrinterUtils(self._printer, self._file_manager)
+        PrinterHandler.initialize(self)
+
+    # Using composition for PrinterUtils instead of inheritance
+    def getCurrentJobFilamentUsage(self):
+        return self._printer_utils.getCurrentJobFilamentUsage()
 
     # TODO: Investigate caching again in the future.
     # Currently re-instantiating is fine, as there's nothing "heavy" in the ctor,

--- a/octoprint_Spoolman/SpoolmanPlugin.py
+++ b/octoprint_Spoolman/SpoolmanPlugin.py
@@ -56,10 +56,8 @@ class SpoolmanPlugin(
         )
 
     def triggerPluginEvent(self, eventType, eventPayload = {}):
-        # Sicherstellen, dass der Event-Name korrekt für OctoPrint formatiert wird
-        # OctoPrint-Event-Namen sollten das Format "plugin_pluginId_eventName" haben
+        # Füge das "plugin_Spoolman_" Präfix hinzu, wenn es noch nicht vorhanden ist
         if not eventType.startswith("plugin_"):
-            # Füge das "plugin_Spoolman_" Präfix hinzu, wenn es noch nicht vorhanden ist
             eventType = f"plugin_Spoolman_{eventType}"
             
         self._logger.info("[Spoolman][event] Triggered '" + eventType + "' with payload '" + str(eventPayload) + "'")
@@ -215,7 +213,6 @@ class SpoolmanPlugin(
             selected_spool_ids = self._settings.get([SettingsKeys.SELECTED_SPOOL_IDS])
             
             # Spule für das angegebene Tool auswählen
-            # Die Spulen-ID muss als Observable-kompatibles Format gespeichert werden
             selected_spool_ids[tool_index] = {
                 'spoolId': str(spool_id)
             }
@@ -224,7 +221,7 @@ class SpoolmanPlugin(
             self._settings.set([SettingsKeys.SELECTED_SPOOL_IDS], selected_spool_ids)
             self._settings.save()
             
-            # Event auslösen mit korrektem Datenformat - das "plugin_Spoolman_" Präfix wird automatisch hinzugefügt
+            # Event auslösen
             self.triggerPluginEvent(
                 PluginEvents.SPOOL_SELECTED,
                 {

--- a/octoprint_Spoolman/SpoolmanPlugin.py
+++ b/octoprint_Spoolman/SpoolmanPlugin.py
@@ -11,14 +11,14 @@ from .common.events import PluginEvents
 
 class SpoolmanPlugin(
     octoprint.plugin.StartupPlugin,
+    octoprint.plugin.SettingsPlugin,
     octoprint.plugin.AssetPlugin,
     octoprint.plugin.TemplatePlugin,
-    octoprint.plugin.SettingsPlugin,
     octoprint.plugin.EventHandlerPlugin,
-    octoprint.plugin.BlueprintPlugin,  # Added for API endpoints
-    PluginAPI,
-    PrinterHandler,
+    octoprint.plugin.BlueprintPlugin,
     PrinterUtils,
+    PrinterHandler,
+    PluginAPI
 ):
     _isInitialized = False
 

--- a/octoprint_Spoolman/SpoolmanPlugin.py
+++ b/octoprint_Spoolman/SpoolmanPlugin.py
@@ -206,25 +206,30 @@ class SpoolmanPlugin(
             selected_spool_ids = self._settings.get([SettingsKeys.SELECTED_SPOOL_IDS])
             
             # Spule für das angegebene Tool auswählen
-            selected_spool_ids[tool] = spool_id
+            # Die Spulen-ID muss als Dictionary mit 'spoolId' gespeichert werden, 
+            # damit sie korrekt mit der UI-Logik funktioniert
+            tool_index = tool.replace("tool", "") if tool.startswith("tool") else tool
+            selected_spool_ids[tool_index] = {
+                'spoolId': str(spool_id)
+            }
             
             # Settings aktualisieren
             self._settings.set([SettingsKeys.SELECTED_SPOOL_IDS], selected_spool_ids)
             self._settings.save()
             
-            # Event auslösen
+            # Event auslösen mit korrektem Datenformat
             self.triggerPluginEvent(
                 PluginEvents.SPOOL_SELECTED,
                 {
-                    "toolIndex": tool,
-                    "spoolId": spool_id
+                    'toolIdx': int(tool_index),
+                    'spoolId': str(spool_id)
                 }
             )
             
             return jsonify({
                 "success": True,
                 "selected_spool": spool_id,
-                "tool": tool
+                "tool": tool_index
             }), 200
             
         except Exception as e:

--- a/octoprint_Spoolman/modules/PluginAPI.py
+++ b/octoprint_Spoolman/modules/PluginAPI.py
@@ -9,7 +9,7 @@ import http
 from ..common.settings import SettingsKeys
 from .PrinterUtils import PrinterUtils
 
-class PluginAPI(octoprint.plugin.BlueprintPlugin):
+class PluginAPI(object):
     def is_blueprint_csrf_protected(self):
         return True
 

--- a/octoprint_Spoolman/modules/PluginAPI.py
+++ b/octoprint_Spoolman/modules/PluginAPI.py
@@ -7,7 +7,6 @@ import flask
 import http
 
 from ..common.settings import SettingsKeys
-from .PrinterUtils import PrinterUtils
 
 class PluginAPI(object):
     def is_blueprint_csrf_protected(self):
@@ -112,6 +111,9 @@ class PluginAPI(object):
 
         selectedSpools = self._settings.get([SettingsKeys.SELECTED_SPOOL_IDS])
 
+        # Use the PrinterUtils static method directly through getCurrentJobFilamentUsage()
+        # This avoids the circular dependency
+        from .PrinterUtils import PrinterUtils
         filamentUsageDataPerTool = PrinterUtils.getFilamentUsageDataPerTool(
             filamentLengthPerTool = jobFilamentUsage['jobFilamentLengthsPerTool'],
             selectedSpoolsPerTool = selectedSpools,

--- a/octoprint_Spoolman/modules/PrinterHandler.py
+++ b/octoprint_Spoolman/modules/PrinterHandler.py
@@ -7,7 +7,7 @@ from octoprint.events import Events
 from ..thirdparty.gcodeInterpreter import gcode
 from ..common.settings import SettingsKeys
 
-class PrinterHandler():
+class PrinterHandler(object):
     def initialize(self):
         self.lastPrintCancelled = False
         self.lastPrintOdometer = None

--- a/octoprint_Spoolman/modules/PrinterUtils.py
+++ b/octoprint_Spoolman/modules/PrinterUtils.py
@@ -4,6 +4,10 @@ from __future__ import absolute_import
 import math
 
 class PrinterUtils(object):
+    def __init__(self, printer, file_manager):
+        self._printer = printer
+        self._file_manager = file_manager
+        
     def getCurrentJobFilamentUsage(self):
         printer = self._printer
         fileManager = self._file_manager

--- a/octoprint_Spoolman/modules/PrinterUtils.py
+++ b/octoprint_Spoolman/modules/PrinterUtils.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 import math
 
-class PrinterUtils:
+class PrinterUtils(object):
     def getCurrentJobFilamentUsage(self):
         printer = self._printer
         fileManager = self._file_manager

--- a/octoprint_Spoolman/static/js/Spoolman_sidebar.js
+++ b/octoprint_Spoolman/static/js/Spoolman_sidebar.js
@@ -34,49 +34,34 @@ $(() => {
          * it acts like that "generic place" for now.
          */
         const initSocket = async () => {
-            console.log("[Spoolman Debug] Initializing WebSocket listener");
-            
             OctoPrint.socket.onMessage("event", (message) => {
-                console.log("[Spoolman Debug] Received socket message:", message);
-                
                 if (!(message.data.type || '').includes("plugin_Spoolman_")) {
                     return;
                 }
-                
-                console.log("[Spoolman Debug] Processing Spoolman event:", message.data.type, message.data.payload);
                 handlePluginSocketEvents(message.data.type, message.data.payload);
             });
         };
 
         const updateSelectedSpools = async () => {
-            console.log("[Spoolman Debug] Updating selected spools display");
             self.templateData.loadingError(undefined);
             self.templateData.isLoadingData(true);
 
             try {
                 const spoolmanSpoolsResult = await pluginSpoolmanApi.getSpoolmanSpools();
-                console.log("[Spoolman Debug] Got spools data:", spoolmanSpoolsResult);
-                
                 self.templateData.isLoadingData(false);
 
                 if (!spoolmanSpoolsResult.isSuccess) {
                     const responseError = spoolmanSpoolsResult.error.response.error;
-
                     const code = Object.values(self.constants.knownErrors).includes(responseError?.code)
                         ? responseError?.code
                         : undefined;
-
-                    console.error("[Spoolman Debug] Error loading spools:", responseError);
                     self.templateData.loadingError({
                         code,
                     });
-
                     return;
                 }
 
                 const spoolmanSpools = spoolmanSpoolsResult.payload.response.data.spools;
-                console.log("[Spoolman Debug] Available spools:", spoolmanSpools);
-
                 const currentProfileData = self.settingsViewModel.printerProfiles.currentProfileData();
                 const currentExtrudersCount = (
                     currentProfileData
@@ -88,28 +73,13 @@ $(() => {
                     length: currentExtrudersCount
                 }, () => undefined);
 
-                // WICHTIG: Die selectedSpoolIds neu laden, um sicherzustellen, dass wir aktuelle Daten haben
-                const settings = self.settingsViewModel.settings.plugins[PLUGIN_ID];
-                // Force reload settings if needed
-                if (settings && typeof settings.selectedSpoolIds === 'object') {
-                    // Wir müssen die Settings neu aus dem ViewModel laden
-                    console.log("[Spoolman Debug] Current settings:", settings);
-                    console.log("[Spoolman Debug] Current selectedSpoolIds:", settings.selectedSpoolIds);
-                }
-
                 const selectedSpoolIds = getPluginSettings().selectedSpoolIds;
-                console.log("[Spoolman Debug] Selected spool IDs:", selectedSpoolIds);
                 
                 const selectedSpools = extruders.map((_, extruderIdx) => {
                     const toolIdxStr = String(extruderIdx);
                     const spoolIdData = selectedSpoolIds[toolIdxStr];
-                    console.log(`[Spoolman Debug] Looking up spool for tool ${toolIdxStr}:`, spoolIdData);
-                    
                     const spoolId = spoolIdData?.spoolId?.();
-                    console.log(`[Spoolman Debug] Spool ID for tool ${toolIdxStr}:`, spoolId);
-
                     const spoolData = spoolmanSpools.find((spool) => String(spool.id) === spoolId);
-                    console.log(`[Spoolman Debug] Found spool data for tool ${toolIdxStr}:`, spoolData);
 
                     return {
                         spoolId,
@@ -118,7 +88,6 @@ $(() => {
                     };
                 });
 
-                console.log("[Spoolman Debug] Setting selected spools:", selectedSpools);
                 self.templateData.selectedSpoolsByToolIdx(selectedSpools);
                 self.templateData.selectedSpoolsByToolIdx.valueHasMutated();
 
@@ -128,7 +97,6 @@ $(() => {
                 
                 return true;
             } catch (error) {
-                console.error("[Spoolman Debug] Error updating spools:", error);
                 self.templateData.isLoadingData(false);
                 return false;
             }
@@ -139,7 +107,6 @@ $(() => {
          */
         const handleOpenSpoolSelector = async (toolIdx) => {
             self.templateData.modals.selectSpool.toolIdx(toolIdx);
-
             self.modals.selectSpool().modal("show");
         };
 
@@ -159,18 +126,18 @@ $(() => {
             }
 
             await reloadSettingsViewModel(self.settingsViewModel);
-
             updateSelectedSpools();
         };
 
         const handleForceRefresh = async () => {
-            console.log("[Spoolman Debug] Force refreshing spool data");
             pluginSpoolmanApi.getSpoolmanSpools.invalidate();
             return updateSelectedSpools();
         };
+
         const handleTryAgainOnError = async () => {
             await handleForceRefresh();
         };
+
         const handleSpoolUsageError = async (eventPayload) => {
             if (eventPayload.code === "spoolman_api__spool_not_found") {
                 const spoolId = eventPayload.data.spoolId;
@@ -218,29 +185,18 @@ $(() => {
         };
 
         const handlePluginSocketEvents = async (eventType, eventPayload) => {
-            console.log(`[Spoolman Debug] Handling event: ${eventType}`, eventPayload);
-            
-            // Die OctoPrint Event-Namen haben das Format "plugin_Spoolman_spool_selected"
-            // ODER (je nach OctoPrint-Version) "plugin_spoolman_spool_selected"
-            // Daher müssen wir beide Formate abfangen
-            
             if (eventType.toLowerCase().includes("plugin_spoolman_spool_selected")) {
-                console.log("[Spoolman Debug] Spool selected event detected", eventPayload);
-                
                 // Force reload settings to ensure we have the latest data
                 try {
                     await self.settingsViewModel.requestData();
-                    console.log("[Spoolman Debug] Settings reloaded after spool selection");
                     
                     // Invalidate cache to force a fresh data load
                     pluginSpoolmanApi.getSpoolmanSpools.invalidate();
-                    console.log("[Spoolman Debug] API cache invalidated");
                     
                     // Update the UI
-                    const updated = await updateSelectedSpools();
-                    console.log("[Spoolman Debug] UI updated after spool selection:", updated);
+                    await updateSelectedSpools();
                 } catch (error) {
-                    console.error("[Spoolman Debug] Error updating after spool selection:", error);
+                    // Silent error handling
                 }
                 
                 return;

--- a/octoprint_Spoolman/static/js/Spoolman_sidebar.js
+++ b/octoprint_Spoolman/static/js/Spoolman_sidebar.js
@@ -183,7 +183,10 @@ $(() => {
 
         const handlePluginSocketEvents = async (eventType, eventPayload) => {
             if (eventType === "plugin_Spoolman_spool_selected") {
-                return;
+                // Aktualisiere die UI direkt, wenn eine Spule ausgewählt wurde
+                self._logger && self._logger.info("[Spoolman] Detected spool selection, refreshing UI");
+                await handleForceRefresh();
+                return updateSelectedSpools();
             }
             if (eventType === "plugin_Spoolman_spool_usage_committed") {
                 return await handleForceRefresh();

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_Spoolman"
 plugin_name = "octoprint-spoolman"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.3.0"
+plugin_version = "1.3.1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Implemented a Webhook to switch Spools.

## Description
I build the tool [FilaMan](https://github.com/ManuelW77/Filaman) as a companion to Spoolman. 
People ask'd me, if my tool can set the spools in Octo-Spoolman also.
So i implemented a webhook into this nice Octo Plugin.
The Octoprint Token is needed to send requests to the webhook.

## Related Issue / Discussion
[Featrue Request to FilaMan](https://github.com/ManuelW77/Filaman/issues/9)

## How has this been tested?
I tested on my own Octoprint installation.

## Screenshots (if appropriate):
No UI changes.

## Types of changes
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have verified that my changes do not break the overall functionality of the plugin.
