### PR TITLE
feat: Spools sorting (GH-77)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ An OctoPrint plugin integrating with [Spoolman](https://github.com/Donkie/Spoolm
         - By default, `archived` spools are not presented for selection
     - [x] Select & deselect spools for specified tools / extruders
     - [x] Commit spools usage to Spoolman
-- [ ] Spools filtering
+- [x] Spools filtering & sorting
 - [x] Check spools before starting a print
     - [x] Ask the user if the selected spool is correct
     - [x] Warn when no spool is selected

--- a/octoprint_Spoolman/SpoolmanPlugin.py
+++ b/octoprint_Spoolman/SpoolmanPlugin.py
@@ -127,6 +127,7 @@ class SpoolmanPlugin(
             SettingsKeys.SELECTED_SPOOL_IDS: {},
             SettingsKeys.IS_PREPRINT_SPOOL_VERIFY_ENABLED: True,
             SettingsKeys.SHOW_LOT_NUMBER_COLUMN_IN_SPOOL_SELECT_MODAL: False,
+            SettingsKeys.SHOW_LAST_USED_COLUMN_IN_SPOOL_SELECT_MODAL: True,
             SettingsKeys.SHOW_LOT_NUMBER_IN_SIDE_BAR: False,
             SettingsKeys.SHOW_SPOOL_ID_IN_SIDE_BAR: False,
         }

--- a/octoprint_Spoolman/common/settings.py
+++ b/octoprint_Spoolman/common/settings.py
@@ -9,5 +9,6 @@ class SettingsKeys():
 	SELECTED_SPOOL_IDS = "selectedSpoolIds"
 	IS_PREPRINT_SPOOL_VERIFY_ENABLED = "isPreprintSpoolVerifyEnabled"
 	SHOW_LOT_NUMBER_COLUMN_IN_SPOOL_SELECT_MODAL = "showLotNumberColumnInSpoolSelectModal"
+	SHOW_LAST_USED_COLUMN_IN_SPOOL_SELECT_MODAL = "showLastUsedColumnInSpoolSelectModal"
 	SHOW_LOT_NUMBER_IN_SIDE_BAR = "showLotNumberInSidebar"
 	SHOW_SPOOL_ID_IN_SIDE_BAR = "showSpoolIdInSidebar"

--- a/octoprint_Spoolman/static/js/Spoolman_modal_selectSpool.js
+++ b/octoprint_Spoolman/static/js/Spoolman_modal_selectSpool.js
@@ -90,6 +90,7 @@ $(() => {
             self.templateData.spoolmanUrl(getPluginSettings().spoolmanUrl());
 
             self.templateData.tableAttributeVisibility.lot(Boolean(getPluginSettings().showLotNumberColumnInSpoolSelectModal()));
+            self.templateData.tableAttributeVisibility.lastUsed(Boolean(getPluginSettings().showLastUsedColumnInSpoolSelectModal()));
 
             refreshModalLayout();
         };
@@ -179,6 +180,7 @@ $(() => {
                 spoolName: true,
                 material: true,
                 lot: ko.observable(Boolean(getPluginSettings().showLotNumberColumnInSpoolSelectModal())),
+                lastUsed: ko.observable(Boolean(getPluginSettings().showLastUsedColumnInSpoolSelectModal())),
                 weight: true,
             },
             tableItemsOnCurrentPage: ko.observable([]),
@@ -206,6 +208,12 @@ $(() => {
                     // For weight, use `remaining_weight`
                     return tableItem.displayData.remaining_weight.isValid ?
                         parseFloat(tableItem.displayData.remaining_weight.displayValue) : 0;
+                case 'lastUsed':
+                    if (!tableItem.spoolData.last_used) {
+                        return -1;
+                    }
+
+                    return (new Date(tableItem.spoolData.last_used)).getTime();
                 default:
                     return '';
             }

--- a/octoprint_Spoolman/static/js/api/getSpoolmanSpools.js
+++ b/octoprint_Spoolman/static/js/api/getSpoolmanSpools.js
@@ -11,6 +11,11 @@
  * @property {number} id
  * @property {boolean} archived
  * @property {string} registered
+ *  When the spool was registered in the database. UTC Timezone. ISO 8601 format.
+ * @property {string | null} first_used
+ *  First logged occurence of spool usage. UTC Timezone. ISO 8601 format.
+ * @property {string | null} last_used
+ *  Last logged occurence of spool usage. UTC Timezone. ISO 8601 format.
  * @property {number} used_length
  * @property {number} used_weight
  * @property {number | undefined} remaining_length

--- a/octoprint_Spoolman/static/js/common/formatting.js
+++ b/octoprint_Spoolman/static/js/common/formatting.js
@@ -1,11 +1,10 @@
-
 /**
  * @param {number} weight
  * @param {{
-*  constants: Record<string, unknown>;
-*  precision?: number
-* }} params
-*/
+ *  constants: Record<string, unknown>;
+ *  precision?: number
+ * }} params
+ */
 const toWeight = (weight, params) => {
     return `${weight.toFixed(params.precision ?? 1)}${params.constants['weight_unit']}`;
 };
@@ -13,9 +12,9 @@ const toWeight = (weight, params) => {
 /**
  * @param {Spool} spool
  * @param {{
-*  constants: Record<string, unknown>
-* }} params
-*/
+ *  constants: Record<string, unknown>
+ * }} params
+ */
 const toSpoolForDisplay = (spool, params) => {
     return {
         filament: {
@@ -121,9 +120,9 @@ const calculateWeight = (length, diameter, density) => {
  * @param {string | undefined} multi_color_hexes
  *  Hex color codes for multi-color filaments or undefined
  * @returns {{
-*   cssProperty: string,
-*   cssValue: string,
-*  }}
+ *   cssProperty: string,
+ *   cssValue: string,
+ *  }}
  *  cssProperty and cssValue for the filament color
  */
 const calculateColorCSS = (color_hex, multi_color_direction, multi_color_hexes) => {

--- a/octoprint_Spoolman/static/js/common/formatting.js
+++ b/octoprint_Spoolman/static/js/common/formatting.js
@@ -73,6 +73,16 @@ const toSpoolForDisplay = (spool, params) => {
                     displayValue: "Unavailable",
                 }
         ),
+        last_used: (
+            spool.last_used
+                ? {
+                    isValid: true,
+                    displayValue: formatDateForDisplay(spool.last_used),
+                } : {
+                    isValid: false,
+                    displayValue: "N/A",
+                }
+        ),
         lot: (
             spool.lot_nr
                 ? {
@@ -175,3 +185,30 @@ const calculateShortLot = (lot_nr) => {
 
     return `${lot_nr.substring(0, 3)}...${lot_nr.substring(lot_nr.length - 3)}`;
 }
+
+/**
+ * @param {string} dateString
+ *  ISO 8601 date string
+ * @returns string
+ *  Formatted date string in YYYY-MM-dd HH:mm:ss format
+ */
+const formatDateForDisplay = (dateString) => {
+    if (!dateString) {
+        return '';
+    }
+
+    const dateWrapper = new Date(dateString);
+
+    if (isNaN(dateWrapper.getTime())) {
+        return dateString;
+    }
+
+    const year = dateWrapper.getFullYear();
+    const month = String(dateWrapper.getMonth() + 1).padStart(2, '0');
+    const day = String(dateWrapper.getDate()).padStart(2, '0');
+    const hours = String(dateWrapper.getHours()).padStart(2, '0');
+    const minutes = String(dateWrapper.getMinutes()).padStart(2, '0');
+    const seconds = String(dateWrapper.getSeconds()).padStart(2, '0');
+
+    return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
+};

--- a/octoprint_Spoolman/templates/Spoolman_settings.jinja2
+++ b/octoprint_Spoolman/templates/Spoolman_settings.jinja2
@@ -152,6 +152,29 @@
                         </div>
                     </div>
                 </div>
+                <div class="control-group">
+                    <label
+                        class="control-label"
+                        for="settings-spoolman-display-settings-showLastUsedColumnInSpoolSelectModal"
+                    >
+                        Show Last Used column in Spool Select Modal
+                    </label>
+                    <div class="controls">
+                        <div>
+                            <input
+                                id="settings-spoolman-display-settings-showLastUsedColumnInSpoolSelectModal"
+                                type="checkbox"
+                                class="text-left"
+                                data-bind="checked: pluginSettings.showLastUsedColumnInSpoolSelectModal"
+                            >
+                        </div>
+                        <div style="margin-top: 0.25em">
+                            <small>
+                                If enabled, the "Last Used" column will be displayed in the Spool Select Modal. The column will show the last used date of the spool, if available.
+                            </small>
+                        </div>
+                    </div>
+                </div>
                 <hr>
                 <div class="control-group">
                     <label

--- a/octoprint_Spoolman/templates/Spoolman_sidebar_modal_selectspool.jinja2
+++ b/octoprint_Spoolman/templates/Spoolman_sidebar_modal_selectspool.jinja2
@@ -120,40 +120,70 @@
                     <thead>
                         <tr>
                             <th
-                                style="width: 5%"
-                                data-bind="visible: templateData.tableAttributeVisibility.id"
+                                style="width: 5%; cursor: pointer;"
+                                data-bind="visible: templateData.tableAttributeVisibility.id, click: function() { templateApi.handleSortChange('id') }"
                             >
                                 ID
+                                <!-- ko if: templateData.sortField() === 'id' -->
+                                <i class="fa" data-bind="css: { 'fa-sort-up': templateData.sortDirection() === 'asc', 'fa-sort-down': templateData.sortDirection() === 'desc' }"></i>
+                                <!-- /ko -->
+                                <!-- ko ifnot: templateData.sortField() === 'id' -->
+                                <i class="fa fa-sort muted"></i>
+                                <!-- /ko -->
                             </th>
                             <th
-                                style="width: 50%"
-                                data-bind="visible: templateData.tableAttributeVisibility.spoolName"
+                                style="width: 50%; cursor: pointer;"
+                                data-bind="visible: templateData.tableAttributeVisibility.spoolName, click: function() { templateApi.handleSortChange('spoolName') }"
                             >
                                 Name
+                                <!-- ko if: templateData.sortField() === 'spoolName' -->
+                                <i class="fa" data-bind="css: { 'fa-sort-up': templateData.sortDirection() === 'asc', 'fa-sort-down': templateData.sortDirection() === 'desc' }"></i>
+                                <!-- /ko -->
+                                <!-- ko ifnot: templateData.sortField() === 'spoolName' -->
+                                <i class="fa fa-sort muted"></i>
+                                <!-- /ko -->
                             </th>
                             <th
-                                style="width: 15%"
-                                data-bind="visible: templateData.tableAttributeVisibility.material"
+                                style="width: 15%; cursor: pointer;"
+                                data-bind="visible: templateData.tableAttributeVisibility.material, click: function() { templateApi.handleSortChange('material') }"
                             >
                                 Material
+                                <!-- ko if: templateData.sortField() === 'material' -->
+                                <i class="fa" data-bind="css: { 'fa-sort-up': templateData.sortDirection() === 'asc', 'fa-sort-down': templateData.sortDirection() === 'desc' }"></i>
+                                <!-- /ko -->
+                                <!-- ko ifnot: templateData.sortField() === 'material' -->
+                                <i class="fa fa-sort muted"></i>
+                                <!-- /ko -->
                             </th>
                             <th
-                                style="width: 15%"
-                                data-bind="visible: templateData.tableAttributeVisibility.lot"
+                                style="width: 15%; cursor: pointer;"
+                                data-bind="visible: templateData.tableAttributeVisibility.lot, click: function() { templateApi.handleSortChange('lot') }"
                             >
                                 Lot #
+                                <!-- ko if: templateData.sortField() === 'lot' -->
+                                <i class="fa" data-bind="css: { 'fa-sort-up': templateData.sortDirection() === 'asc', 'fa-sort-down': templateData.sortDirection() === 'desc' }"></i>
+                                <!-- /ko -->
+                                <!-- ko ifnot: templateData.sortField() === 'lot' -->
+                                <i class="fa fa-sort muted"></i>
+                                <!-- /ko -->
                             </th>
                             <th
-                                style="text-align: center; width: 15%;"
-                                data-bind="visible: templateData.tableAttributeVisibility.weight"
+                                style="text-align: right; width: 15%; cursor: pointer;"
+                                data-bind="visible: templateData.tableAttributeVisibility.weight, click: function() { templateApi.handleSortChange('weight') }"
                             >
                                 Weight
+                                <!-- ko if: templateData.sortField() === 'weight' -->
+                                <i class="fa" data-bind="css: { 'fa-sort-up': templateData.sortDirection() === 'asc', 'fa-sort-down': templateData.sortDirection() === 'desc' }"></i>
+                                <!-- /ko -->
+                                <!-- ko ifnot: templateData.sortField() === 'weight' -->
+                                <i class="fa fa-sort muted"></i>
+                                <!-- /ko -->
                             </th>
                         </tr>
                     </thead>
 
-                    <!-- ko if: (templateData.filteredTableItemsOnCurrentPage().length > 0) -->
-                        <tbody data-bind="foreach: templateData.filteredTableItemsOnCurrentPage">
+                    <!-- ko if: (templateData.computedTableItemsOnCurrentPage().length > 0) -->
+                        <tbody data-bind="foreach: templateData.computedTableItemsOnCurrentPage">
                             <tr
                                 style="cursor: pointer;"
                                 data-bind="
@@ -235,7 +265,7 @@
                             </tr>
                         </tbody>
                     <!-- /ko -->
-                    <!-- ko if: (templateData.tableItemsOnCurrentPage().length > 0 && templateData.filteredTableItemsOnCurrentPage().length === 0) -->
+                    <!-- ko if: (templateData.tableItemsOnCurrentPage().length > 0 && templateData.computedTableItemsOnCurrentPage().length === 0) -->
                         <tbody>
                             <tr>
                                 <td

--- a/octoprint_Spoolman/templates/Spoolman_sidebar_modal_selectspool.jinja2
+++ b/octoprint_Spoolman/templates/Spoolman_sidebar_modal_selectspool.jinja2
@@ -132,7 +132,7 @@
                                 <!-- /ko -->
                             </th>
                             <th
-                                style="width: 50%; cursor: pointer;"
+                                style="width: 40%; cursor: pointer;"
                                 data-bind="visible: templateData.tableAttributeVisibility.spoolName, click: function() { templateApi.handleSortChange('spoolName') }"
                             >
                                 Name
@@ -164,6 +164,18 @@
                                 <i class="fa" data-bind="css: { 'fa-sort-up': templateData.sortDirection() === 'asc', 'fa-sort-down': templateData.sortDirection() === 'desc' }"></i>
                                 <!-- /ko -->
                                 <!-- ko ifnot: templateData.sortField() === 'lot' -->
+                                <i class="fa fa-sort muted"></i>
+                                <!-- /ko -->
+                            </th>
+                            <th
+                                style="width: 15%; cursor: pointer;"
+                                data-bind="visible: templateData.tableAttributeVisibility.lastUsed, click: function() { templateApi.handleSortChange('lastUsed') }"
+                            >
+                                Last used
+                                <!-- ko if: templateData.sortField() === 'lastUsed' -->
+                                <i class="fa" data-bind="css: { 'fa-sort-up': templateData.sortDirection() === 'asc', 'fa-sort-down': templateData.sortDirection() === 'desc' }"></i>
+                                <!-- /ko -->
+                                <!-- ko ifnot: templateData.sortField() === 'lastUsed' -->
                                 <i class="fa fa-sort muted"></i>
                                 <!-- /ko -->
                             </th>
@@ -234,8 +246,17 @@
                                 <td data-bind="visible: $component.templateData.tableAttributeVisibility.material">
                                     <span data-bind="text: $data.displayData.filament.material.displayValue, attr: { title: $data.displayData.filament.material.displayValue }"></span>
                                 </td>
-                                <td data-bind="visible: $component.templateData.tableAttributeVisibility.lot" style="overflow-wrap: break-word;">
+                                <td
+                                    data-bind="visible: $component.templateData.tableAttributeVisibility.lot"
+                                    style="overflow-wrap: break-word;"
+                                >
                                     <span data-bind="text: $data.displayData.lot.displayValue, attr: { title: $data.displayData.lot.displayValue }"></span>
+                                </td>
+                                <td
+                                    data-bind="visible: $component.templateData.tableAttributeVisibility.lastUsed"
+                                    style="overflow-wrap: break-word;"
+                                >
+                                    <span data-bind="text: $data.displayData.last_used.displayValue, attr: { title: $data.displayData.last_used.displayValue }"></span>
                                 </td>
                                 <td
                                     data-bind="visible: $component.templateData.tableAttributeVisibility.weight" style="text-align: right;"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description

Initial implementation of the requested "filter & sort" functionalities for #77.

Changelog:
- Added basic sorting capability when selecting spool
  - Sortable by all visible columns
  - Default sorting: by ID, ascending order (previously, no sorting at all, items displayed "as is" from the Spoolman's response)
- Added `Last used` field
  - Ability to toggle field's visibility
  - Ability to use field as sorting column

## Related Issue / Discussion

Related issue: #77 

## How has this been tested?

See screenshots below

## Screenshots (if appropriate):

<img width="1146" height="922" alt="obraz" src="https://github.com/user-attachments/assets/d8db029d-fe39-4ba8-8428-7c88b6b04c12" />
<img width="1152" height="1124" alt="obraz" src="https://github.com/user-attachments/assets/1d367ba7-e4db-4013-8e3a-17da2a5c2f06" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have verified that my changes do not break the overall functionality of the plugin.
