### PR TITLE
Fix bug with unverified SSL cert

### DIFF
--- a/octoprint_Spoolman/modules/SpoolmanConnector.py
+++ b/octoprint_Spoolman/modules/SpoolmanConnector.py
@@ -166,12 +166,13 @@ class SpoolmanConnector():
 
         try:
             session = requests.Session()
-            session.verify = self.verifyConfig
+            session.verify = self.verifyConfig # this get's ignored when REQUESTS_CA_BUNDLE environment variable is set according to https://github.com/psf/requests/issues/3829 (02.12.2025)
 
             session.mount(self.instanceUrl, HTTPAdapter(max_retries=retries))
 
             response = session.put(
                 url = endpointUrl,
+                verify = self.verifyConfig, # see above, remove as soon as requests library is fixed
                 json = {
                     'use_length': spoolUsedLength,
                 },


### PR DESCRIPTION
Fix bug with unverified SSL cert (verify ignored on post request)

## Description
Temporary fix for a bug regarding disabled SSL verification on spool usage supoort due to a bug in python's requests library:
https://github.com/psf/requests/issues/3829 (02.12.2025)

## Related Issue / Discussion
#89 

## How has this been tested?
- Created temporary package 1.4.1 of the plugin
- Installed on my OctoPi
- Did multiple prints and usage got reported successfully with SSL verification disabled

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have verified that my changes do not break the overall functionality of the plugin.
