### PR TITLE
Add "Location" Field to Spool Select Modal

### DIFF
--- a/octoprint_Spoolman/SpoolmanPlugin.py
+++ b/octoprint_Spoolman/SpoolmanPlugin.py
@@ -137,6 +137,7 @@ class SpoolmanPlugin(
             SettingsKeys.IS_PREPRINT_SPOOL_VERIFY_ENABLED: True,
             SettingsKeys.SHOW_LOT_NUMBER_COLUMN_IN_SPOOL_SELECT_MODAL: False,
             SettingsKeys.SHOW_LAST_USED_COLUMN_IN_SPOOL_SELECT_MODAL: True,
+            SettingsKeys.SHOW_LOCATION_COLUMN_IN_SPOOL_SELECT_MODAL: False,
             SettingsKeys.SHOW_LOT_NUMBER_IN_SIDE_BAR: False,
             SettingsKeys.SHOW_SPOOL_ID_IN_SIDE_BAR: False,
             SettingsKeys.IS_SPOOLMAN_API_KEY_ENABLED: False,

--- a/octoprint_Spoolman/common/settings.py
+++ b/octoprint_Spoolman/common/settings.py
@@ -11,6 +11,7 @@ class SettingsKeys():
 	IS_PREPRINT_SPOOL_VERIFY_ENABLED = "isPreprintSpoolVerifyEnabled"
 	SHOW_LOT_NUMBER_COLUMN_IN_SPOOL_SELECT_MODAL = "showLotNumberColumnInSpoolSelectModal"
 	SHOW_LAST_USED_COLUMN_IN_SPOOL_SELECT_MODAL = "showLastUsedColumnInSpoolSelectModal"
+	SHOW_LOCATION_COLUMN_IN_SPOOL_SELECT_MODAL = "showLocationColumnInSpoolSelectModal"
 	SHOW_LOT_NUMBER_IN_SIDE_BAR = "showLotNumberInSidebar"
 	SHOW_SPOOL_ID_IN_SIDE_BAR = "showSpoolIdInSidebar"
 	IS_SPOOLMAN_API_KEY_ENABLED = "isSpoolmanApiKeyEnabled"

--- a/octoprint_Spoolman/static/js/Spoolman_modal_selectSpool.js
+++ b/octoprint_Spoolman/static/js/Spoolman_modal_selectSpool.js
@@ -219,6 +219,8 @@ $(() => {
                     }
 
                     return (new Date(tableItem.spoolData.last_used)).getTime();
+				case 'location':
+					return tableItem.displayData.location.displayValue.toLowerCase();
                 default:
                     return '';
             }

--- a/octoprint_Spoolman/static/js/Spoolman_modal_selectSpool.js
+++ b/octoprint_Spoolman/static/js/Spoolman_modal_selectSpool.js
@@ -92,6 +92,8 @@ $(() => {
 
             self.templateData.tableAttributeVisibility.lot(Boolean(getPluginSettings().showLotNumberColumnInSpoolSelectModal()));
             self.templateData.tableAttributeVisibility.lastUsed(Boolean(getPluginSettings().showLastUsedColumnInSpoolSelectModal()));
+            self.templateData.tableAttributeVisibility.location(Boolean(getPluginSettings().showLocationColumnInSpoolSelectModal()));
+
 
             refreshModalLayout();
         };
@@ -182,6 +184,7 @@ $(() => {
                 material: true,
                 lot: ko.observable(Boolean(getPluginSettings().showLotNumberColumnInSpoolSelectModal())),
                 lastUsed: ko.observable(Boolean(getPluginSettings().showLastUsedColumnInSpoolSelectModal())),
+				location: ko.observable(Boolean(getPluginSettings().showLocationColumnInSpoolSelectModal())),
                 weight: true,
             },
             tableItemsOnCurrentPage: ko.observable([]),

--- a/octoprint_Spoolman/static/js/common/formatting.js
+++ b/octoprint_Spoolman/static/js/common/formatting.js
@@ -92,6 +92,16 @@ const toSpoolForDisplay = (spool, params) => {
                     displayValue: "N/A",
                 }
         ),
+		location: (
+		    spool.location
+			? {
+				displayShort: spool.location,
+				displayValue: spool.location,
+			} : {
+				displayShort: "N/A",
+				displayValue: "N/A",
+			}
+		),
     };
 };
 

--- a/octoprint_Spoolman/templates/Spoolman_settings.jinja2
+++ b/octoprint_Spoolman/templates/Spoolman_settings.jinja2
@@ -305,6 +305,29 @@
                         </div>
                     </div>
                 </div>
+                <div class="control-group">
+                    <label
+                        class="control-label"
+                        for="settings-spoolman-display-settings-showLocationColumnInSpoolSelectModal"
+                    >
+                        Show Location column in Spool Select Modal
+                    </label>
+                    <div class="controls">
+                        <div>
+                            <input
+                                id="settings-spoolman-display-settings-showLocationColumnInSpoolSelectModal"
+                                type="checkbox"
+                                class="text-left"
+                                data-bind="checked: pluginSettings.showLocationColumnInSpoolSelectModal"
+                            >
+                        </div>
+                        <div style="margin-top: 0.25em">
+                            <small>
+                                If enabled, the "Location" column will be displayed in the Spool Select Modal. The column will show the location of the spool, if available.
+                            </small>
+                        </div>
+                    </div>
+                </div>
                 <hr>
                 <div class="control-group">
                     <label

--- a/octoprint_Spoolman/templates/Spoolman_sidebar_modal_selectspool.jinja2
+++ b/octoprint_Spoolman/templates/Spoolman_sidebar_modal_selectspool.jinja2
@@ -179,6 +179,18 @@
                                 <i class="fa fa-sort muted"></i>
                                 <!-- /ko -->
                             </th>
+							<th
+                                style="width: 15%; cursor: pointer;"
+                                data-bind="visible: templateData.tableAttributeVisibility.location, click: function() { templateApi.handleSortChange('location') }"
+                            >
+                                Location
+                                <!-- ko if: templateData.sortField() === 'location' -->
+                                <i class="fa" data-bind="css: { 'fa-sort-up': templateData.sortDirection() === 'asc', 'fa-sort-down': templateData.sortDirection() === 'desc' }"></i>
+                                <!-- /ko -->
+                                <!-- ko ifnot: templateData.sortField() === 'location' -->
+                                <i class="fa fa-sort muted"></i>
+                                <!-- /ko -->
+                            </th>
                             <th
                                 style="text-align: right; width: 15%; cursor: pointer;"
                                 data-bind="visible: templateData.tableAttributeVisibility.weight, click: function() { templateApi.handleSortChange('weight') }"
@@ -258,6 +270,12 @@
                                 >
                                     <span data-bind="text: $data.displayData.last_used.displayValue, attr: { title: $data.displayData.last_used.displayValue }"></span>
                                 </td>
+								<td
+                                    data-bind="visible: $component.templateData.tableAttributeVisibility.location"
+                                    style="overflow-wrap: break-word;"
+                                >
+                                    <span data-bind="text: $data.displayData.location.displayValue, attr: { title: $data.displayData.location.displayValue }"></span>
+                                </td>
                                 <td
                                     data-bind="visible: $component.templateData.tableAttributeVisibility.weight" style="text-align: right;"
                                 >
@@ -276,7 +294,7 @@
                         <tbody>
                             <tr>
                                 <td
-                                    colspan="4"
+                                    colspan="5"
                                     style="text-align: center;"
                                 >
                                     <i class="muted">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes. Please provide context & motivation for the changes. -->

This is a few small changes to link the "Location" field of Spoolman to be available in the dialog for selecting a spool. I have also added the setting to turn this feature on and off. It is off by default.

## Related Issue / Discussion
<!--- Pull requests should be related to open issues or discussions. -->
<!--- Please follow the guide provided in CONTRIBUTING.md file, before submitting a new Pull request. -->
<!--- Please link to the issue / discussion here: -->
This is related to issue #66. 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and what testing steps have been taken to verify the changes' correctness. -->
<!--- Please validate if other functionalities have not been negatively affected. -->
This has been tested in the provided Docker development environment and on a production OctoPrint system running on a Raspberry Pi 3 running OctoPrint 1.11.7 connected to a Prusa i3 MK3S+ with MMU3. As far as I can tell, the rest of the plugin has been unaffected and selecting spools is now easier.

## Screenshots (if appropriate):

<img width="959" height="640" alt="image" src="https://github.com/user-attachments/assets/c2fdb9e2-42db-443d-94a9-9265cc17b27e" />
<img width="952" height="577" alt="image" src="https://github.com/user-attachments/assets/d6a1c44f-ca73-4393-a928-34252f759596" />\
<img width="704" height="522" alt="image" src="https://github.com/user-attachments/assets/2aba4bfd-e3e2-454c-805f-e602d11daba0" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have verified that my changes do not break the overall functionality of the plugin.
