### PR TITLE
Add Automatic Spool Renumbering

### DIFF
--- a/octoprint_Spoolman/SpoolmanPlugin.py
+++ b/octoprint_Spoolman/SpoolmanPlugin.py
@@ -8,6 +8,7 @@ from .modules.SpoolmanConnector import SpoolmanConnector
 from .common.settings import SettingsKeys
 from .common.events import PluginEvents
 
+
 class SpoolmanPlugin(
     octoprint.plugin.StartupPlugin,
     octoprint.plugin.AssetPlugin,
@@ -27,12 +28,14 @@ class SpoolmanPlugin(
     # Currently re-instantiating is fine, as there's nothing "heavy" in the ctor,
     # nor there's any useful persistence in the class itself.
     def getSpoolmanConnector(self):
-        spoolmanInstanceUrl = self._settings.get([ SettingsKeys.SPOOLMAN_URL ])
+        spoolmanInstanceUrl = self._settings.get([SettingsKeys.SPOOLMAN_URL])
 
         verifyConfig = None
 
-        isSpoolmanCertVerifyEnabled = self._settings.get([ SettingsKeys.IS_SPOOLMAN_CERT_VERIFY_ENABLED ])
-        spoolmanCertPemPath = self._settings.get([ SettingsKeys.SPOOLMAN_CERT_PEM_PATH ])
+        isSpoolmanCertVerifyEnabled = self._settings.get(
+            [SettingsKeys.IS_SPOOLMAN_CERT_VERIFY_ENABLED]
+        )
+        spoolmanCertPemPath = self._settings.get([SettingsKeys.SPOOLMAN_CERT_PEM_PATH])
 
         if isSpoolmanCertVerifyEnabled:
             if spoolmanCertPemPath:
@@ -42,26 +45,41 @@ class SpoolmanPlugin(
         else:
             verifyConfig = False
 
-        isSpoolmanApiKeyEnabled = self._settings.get([ SettingsKeys.IS_SPOOLMAN_API_KEY_ENABLED ])
-        spoolmanApiKeyHeader = self._settings.get([ SettingsKeys.SPOOLMAN_API_KEY_HEADER ]) if isSpoolmanApiKeyEnabled else None
-        spoolmanApiKey = self._settings.get([ SettingsKeys.SPOOLMAN_API_KEY ]) if isSpoolmanApiKeyEnabled else None
-        isUseRequestRetryLogicEnabled = self._settings.get([ SettingsKeys.IS_USE_REQUEST_RETRY_LOGIC_ENABLED ])
+        isSpoolmanApiKeyEnabled = self._settings.get(
+            [SettingsKeys.IS_SPOOLMAN_API_KEY_ENABLED]
+        )
+        spoolmanApiKeyHeader = (
+            self._settings.get([SettingsKeys.SPOOLMAN_API_KEY_HEADER])
+            if isSpoolmanApiKeyEnabled
+            else None
+        )
+        spoolmanApiKey = (
+            self._settings.get([SettingsKeys.SPOOLMAN_API_KEY])
+            if isSpoolmanApiKeyEnabled
+            else None
+        )
+        isUseRequestRetryLogicEnabled = self._settings.get(
+            [SettingsKeys.IS_USE_REQUEST_RETRY_LOGIC_ENABLED]
+        )
 
         return SpoolmanConnector(
-            instanceUrl = spoolmanInstanceUrl,
-            logger = self._logger,
-            verifyConfig = verifyConfig,
-            apiKeyHeader = spoolmanApiKeyHeader,
-            apiKey = spoolmanApiKey,
-            isRetryLogicEnabled = isUseRequestRetryLogicEnabled,
+            instanceUrl=spoolmanInstanceUrl,
+            logger=self._logger,
+            verifyConfig=verifyConfig,
+            apiKeyHeader=spoolmanApiKeyHeader,
+            apiKey=spoolmanApiKey,
+            isRetryLogicEnabled=isUseRequestRetryLogicEnabled,
         )
 
-    def triggerPluginEvent(self, eventType, eventPayload = {}):
-        self._logger.info("[Spoolman][event] Triggered '" + eventType + "' with payload '" + str(eventPayload) + "'")
-        self._event_bus.fire(
-            eventType,
-            payload = eventPayload
+    def triggerPluginEvent(self, eventType, eventPayload={}):
+        self._logger.info(
+            "[Spoolman][event] Triggered '"
+            + eventType
+            + "' with payload '"
+            + str(eventPayload)
+            + "'"
         )
+        self._event_bus.fire(eventType, payload=eventPayload)
 
     def on_after_startup(self):
         self._logger.info("[Spoolman][init] Plugin activated")
@@ -69,17 +87,19 @@ class SpoolmanPlugin(
     # Printing events handlers
     def on_event(self, event, payload):
         if (
-            event == Events.PRINT_STARTED or
-            event == Events.PRINT_PAUSED or
-            event == Events.PRINT_DONE or
-            event == Events.PRINT_FAILED or
-            event == Events.PRINT_CANCELLED
+            event == Events.PRINT_STARTED
+            or event == Events.PRINT_PAUSED
+            or event == Events.PRINT_DONE
+            or event == Events.PRINT_FAILED
+            or event == Events.PRINT_CANCELLED
         ):
             self.handlePrintingStatusChange(event)
 
         pass
 
-    def on_sentGCodeHook(self, comm_instance, phase, cmd, cmd_type, gcode, *args, **kwargs):
+    def on_sentGCodeHook(
+        self, comm_instance, phase, cmd, cmd_type, gcode, *args, **kwargs
+    ):
         if not self._isInitialized:
             return
 
@@ -122,7 +142,7 @@ class SpoolmanPlugin(
             {
                 "type": "settings",
                 "template": "Spoolman_settings.jinja2",
-            }
+            },
         ]
 
     # SettingsPlugin
@@ -138,6 +158,7 @@ class SpoolmanPlugin(
             SettingsKeys.SHOW_LOT_NUMBER_COLUMN_IN_SPOOL_SELECT_MODAL: False,
             SettingsKeys.SHOW_LAST_USED_COLUMN_IN_SPOOL_SELECT_MODAL: True,
             SettingsKeys.SHOW_LOT_NUMBER_IN_SIDE_BAR: False,
+            SettingsKeys.RENUMBER_SPOOL_START: False,
             SettingsKeys.SHOW_SPOOL_ID_IN_SIDE_BAR: False,
             SettingsKeys.IS_SPOOLMAN_API_KEY_ENABLED: False,
             SettingsKeys.SPOOLMAN_API_KEY_HEADER: "",
@@ -149,8 +170,8 @@ class SpoolmanPlugin(
 
     def get_settings_restricted_paths(self):
         return {
-            'never': [
-                [ SettingsKeys.SPOOLMAN_API_KEY ],
+            "never": [
+                [SettingsKeys.SPOOLMAN_API_KEY],
             ],
         }
 
@@ -158,11 +179,18 @@ class SpoolmanPlugin(
         self._logger.info("[Spoolman][Settings] Saved data")
 
         # When Api Key usage was disabled, reset header & key values to defaults
-        if SettingsKeys.IS_SPOOLMAN_API_KEY_ENABLED in data and not data[SettingsKeys.IS_SPOOLMAN_API_KEY_ENABLED]:
+        if (
+            SettingsKeys.IS_SPOOLMAN_API_KEY_ENABLED in data
+            and not data[SettingsKeys.IS_SPOOLMAN_API_KEY_ENABLED]
+        ):
             defaultSettings = self.get_settings_defaults()
 
-            data[SettingsKeys.SPOOLMAN_API_KEY_HEADER] = defaultSettings[SettingsKeys.SPOOLMAN_API_KEY_HEADER]
-            data[SettingsKeys.SPOOLMAN_API_KEY] = defaultSettings[SettingsKeys.SPOOLMAN_API_KEY]
+            data[SettingsKeys.SPOOLMAN_API_KEY_HEADER] = defaultSettings[
+                SettingsKeys.SPOOLMAN_API_KEY_HEADER
+            ]
+            data[SettingsKeys.SPOOLMAN_API_KEY] = defaultSettings[
+                SettingsKeys.SPOOLMAN_API_KEY
+            ]
 
         octoprint.plugin.SettingsPlugin.on_settings_save(self, data)
 
@@ -179,16 +207,13 @@ class SpoolmanPlugin(
             "Spoolman": {
                 "displayName": "Spoolman Plugin",
                 "displayVersion": self._plugin_version,
-
                 # version check: github repository
                 "type": "github_release",
                 "user": "mdziekon",
                 "repo": "octoprint-spoolman",
                 "current": self._plugin_version,
-
                 # update method: pip
                 "pip": "https://github.com/mdziekon/octoprint-spoolman/archive/{target_version}.zip",
-
                 "stable_branch": {
                     "name": "Stable",
                     "branch": "stable",
@@ -200,6 +225,6 @@ class SpoolmanPlugin(
                         "branch": "rc",
                         "comittish": ["rc", "stable"],
                     },
-                ]
+                ],
             }
         }

--- a/octoprint_Spoolman/__init__.py
+++ b/octoprint_Spoolman/__init__.py
@@ -8,6 +8,7 @@ __plugin_version__ = "1.4.0"
 __plugin_description__ = "Plugin integrating OctoPrint with Spoolman, a universal filament spools inventory manager."
 __plugin_pythoncompat__ = ">=3.7,<4"
 
+
 def __plugin_load__():
     global __plugin_implementation__
     __plugin_implementation__ = SpoolmanPlugin()

--- a/octoprint_Spoolman/common/events.py
+++ b/octoprint_Spoolman/common/events.py
@@ -1,7 +1,8 @@
 # coding=utf-8
 from __future__ import absolute_import
 
-class PluginEvents():
-	SPOOL_SELECTED = "spool_selected"
-	SPOOL_USAGE_COMMITTED = "spool_usage_committed"
-	SPOOL_USAGE_ERROR = "spool_usage_error"
+
+class PluginEvents:
+    SPOOL_SELECTED = "spool_selected"
+    SPOOL_USAGE_COMMITTED = "spool_usage_committed"
+    SPOOL_USAGE_ERROR = "spool_usage_error"

--- a/octoprint_Spoolman/common/settings.py
+++ b/octoprint_Spoolman/common/settings.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from __future__ import absolute_import
 
+
 class SettingsKeys:
     INSTALLED_VERSION = "installed_version"
     SPOOLMAN_URL = "spoolmanUrl"
@@ -21,4 +22,3 @@ class SettingsKeys:
     SPOOLMAN_API_KEY_HEADER = "spoolmanApiKeyHeader"
     SPOOLMAN_API_KEY = "spoolmanApiKey"
     IS_USE_REQUEST_RETRY_LOGIC_ENABLED = "isUseRequestRetryLogicEnabled"
-

--- a/octoprint_Spoolman/common/settings.py
+++ b/octoprint_Spoolman/common/settings.py
@@ -1,19 +1,24 @@
 # coding=utf-8
 from __future__ import absolute_import
 
-class SettingsKeys():
-	INSTALLED_VERSION = "installed_version"
-	SPOOLMAN_URL = "spoolmanUrl"
-	SPOOLMAN_WEB_URL = "spoolmanWebUrl"
-	IS_SPOOLMAN_CERT_VERIFY_ENABLED = "isSpoolmanCertVerifyEnabled"
-	SPOOLMAN_CERT_PEM_PATH = "spoolmanCertPemPath"
-	SELECTED_SPOOL_IDS = "selectedSpoolIds"
-	IS_PREPRINT_SPOOL_VERIFY_ENABLED = "isPreprintSpoolVerifyEnabled"
-	SHOW_LOT_NUMBER_COLUMN_IN_SPOOL_SELECT_MODAL = "showLotNumberColumnInSpoolSelectModal"
-	SHOW_LAST_USED_COLUMN_IN_SPOOL_SELECT_MODAL = "showLastUsedColumnInSpoolSelectModal"
-	SHOW_LOT_NUMBER_IN_SIDE_BAR = "showLotNumberInSidebar"
-	SHOW_SPOOL_ID_IN_SIDE_BAR = "showSpoolIdInSidebar"
-	IS_SPOOLMAN_API_KEY_ENABLED = "isSpoolmanApiKeyEnabled"
-	SPOOLMAN_API_KEY_HEADER = "spoolmanApiKeyHeader"
-	SPOOLMAN_API_KEY = "spoolmanApiKey"
-	IS_USE_REQUEST_RETRY_LOGIC_ENABLED = "isUseRequestRetryLogicEnabled"
+class SettingsKeys:
+    INSTALLED_VERSION = "installed_version"
+    SPOOLMAN_URL = "spoolmanUrl"
+    SPOOLMAN_WEB_URL = "spoolmanWebUrl"
+    IS_SPOOLMAN_CERT_VERIFY_ENABLED = "isSpoolmanCertVerifyEnabled"
+    SPOOLMAN_CERT_PEM_PATH = "spoolmanCertPemPath"
+    SELECTED_SPOOL_IDS = "selectedSpoolIds"
+    IS_PREPRINT_SPOOL_VERIFY_ENABLED = "isPreprintSpoolVerifyEnabled"
+    SHOW_LOT_NUMBER_COLUMN_IN_SPOOL_SELECT_MODAL = (
+        "showLotNumberColumnInSpoolSelectModal"
+    )
+    SHOW_LAST_USED_COLUMN_IN_SPOOL_SELECT_MODAL = "showLastUsedColumnInSpoolSelectModal"
+    SHOW_LOCATION_COLUMN_IN_SPOOL_SELECT_MODAL = "showLocationColumnInSpoolSelectModal"
+    SHOW_LOT_NUMBER_IN_SIDE_BAR = "showLotNumberInSidebar"
+    RENUMBER_SPOOL_START = "renumberSpoolStart"
+    SHOW_SPOOL_ID_IN_SIDE_BAR = "showSpoolIdInSidebar"
+    IS_SPOOLMAN_API_KEY_ENABLED = "isSpoolmanApiKeyEnabled"
+    SPOOLMAN_API_KEY_HEADER = "spoolmanApiKeyHeader"
+    SPOOLMAN_API_KEY = "spoolmanApiKey"
+    IS_USE_REQUEST_RETRY_LOGIC_ENABLED = "isUseRequestRetryLogicEnabled"
+

--- a/octoprint_Spoolman/modules/PluginAPI.py
+++ b/octoprint_Spoolman/modules/PluginAPI.py
@@ -9,6 +9,7 @@ import http
 from ..common.settings import SettingsKeys
 from .PrinterUtils import PrinterUtils
 
+
 class PluginAPI(octoprint.plugin.BlueprintPlugin):
     def is_blueprint_csrf_protected(self):
         return True
@@ -37,7 +38,14 @@ class PluginAPI(octoprint.plugin.BlueprintPlugin):
             value = None
 
             errorMessage = str(e)
-            self._logger.error("could not transform value '" + str(value) + "' for key '" + key + "' to int:" + errorMessage)
+            self._logger.error(
+                "could not transform value '"
+                + str(value)
+                + "' for key '"
+                + key
+                + "' to int:"
+                + errorMessage
+            )
 
         return value
 
@@ -47,7 +55,7 @@ class PluginAPI(octoprint.plugin.BlueprintPlugin):
 
         result = self.getSpoolmanConnector().handleGetSpoolsAvailable()
 
-        if result.get('error', False):
+        if result.get("error", False):
             response = flask.jsonify(result)
             response.status = http.HTTPStatus.BAD_REQUEST
 
@@ -67,7 +75,7 @@ class PluginAPI(octoprint.plugin.BlueprintPlugin):
         spools = self._settings.get([SettingsKeys.SELECTED_SPOOL_IDS])
 
         spools[toolId] = {
-            'spoolId': spoolId,
+            "spoolId": spoolId,
         }
 
         self._settings.set([SettingsKeys.SELECTED_SPOOL_IDS], spools)
@@ -76,23 +84,25 @@ class PluginAPI(octoprint.plugin.BlueprintPlugin):
         self.triggerPluginEvent(
             Events.PLUGIN_SPOOLMAN_SPOOL_SELECTED,
             {
-                'toolIdx': toolId,
-                'spoolId': spoolId,
-            }
+                "toolIdx": toolId,
+                "spoolId": spoolId,
+            },
         )
 
-        return flask.jsonify({
-            "data": {}
-        })
+        return flask.jsonify({"data": {}})
 
-    @octoprint.plugin.BlueprintPlugin.route("/self/current-job-requirements", methods=["GET"])
+    @octoprint.plugin.BlueprintPlugin.route(
+        "/self/current-job-requirements", methods=["GET"]
+    )
     def handleGetCurrentJobRequirements(self):
         self._logger.debug("API: GET /self/current-job-requirements")
 
         # TODO: Ideally, this should be pulled from cache
-        getSpoolsAvailableResult = self.getSpoolmanConnector().handleGetSpoolsAvailable()
+        getSpoolsAvailableResult = (
+            self.getSpoolmanConnector().handleGetSpoolsAvailable()
+        )
 
-        if getSpoolsAvailableResult.get('error', False):
+        if getSpoolsAvailableResult.get("error", False):
             response = flask.jsonify(getSpoolsAvailableResult)
             response.status = http.HTTPStatus.BAD_REQUEST
 
@@ -103,24 +113,28 @@ class PluginAPI(octoprint.plugin.BlueprintPlugin):
         jobFilamentUsage = self.getCurrentJobFilamentUsage()
 
         if not jobFilamentUsage["jobHasFilamentLengthData"]:
-            return flask.jsonify({
-                "data": {
-                    "isFilamentUsageAvailable": False,
-                    "tools": {},
-                },
-            })
+            return flask.jsonify(
+                {
+                    "data": {
+                        "isFilamentUsageAvailable": False,
+                        "tools": {},
+                    },
+                }
+            )
 
         selectedSpools = self._settings.get([SettingsKeys.SELECTED_SPOOL_IDS])
 
         filamentUsageDataPerTool = PrinterUtils.getFilamentUsageDataPerTool(
-            filamentLengthPerTool = jobFilamentUsage['jobFilamentLengthsPerTool'],
-            selectedSpoolsPerTool = selectedSpools,
-            spoolsAvailable = spoolsAvailable,
+            filamentLengthPerTool=jobFilamentUsage["jobFilamentLengthsPerTool"],
+            selectedSpoolsPerTool=selectedSpools,
+            spoolsAvailable=spoolsAvailable,
         )
 
-        return flask.jsonify({
-            "data": {
-                "isFilamentUsageAvailable": True,
-                "tools": filamentUsageDataPerTool,
-            },
-        })
+        return flask.jsonify(
+            {
+                "data": {
+                    "isFilamentUsageAvailable": True,
+                    "tools": filamentUsageDataPerTool,
+                },
+            }
+        )

--- a/octoprint_Spoolman/modules/PrinterHandler.py
+++ b/octoprint_Spoolman/modules/PrinterHandler.py
@@ -7,7 +7,8 @@ from octoprint.events import Events
 from ..thirdparty.gcodeInterpreter import gcode
 from ..common.settings import SettingsKeys
 
-class PrinterHandler():
+
+class PrinterHandler:
     def initialize(self):
         self.lastPrintCancelled = False
         self.lastPrintOdometer = None
@@ -29,25 +30,25 @@ class PrinterHandler():
             return
 
         if (
-            eventType == Events.PRINT_PAUSED or
-            eventType == Events.PRINT_DONE or
-            eventType == Events.PRINT_FAILED or
-            eventType == Events.PRINT_CANCELLED
+            eventType == Events.PRINT_PAUSED
+            or eventType == Events.PRINT_DONE
+            or eventType == Events.PRINT_FAILED
+            or eventType == Events.PRINT_CANCELLED
         ):
             self.commitSpoolUsage()
 
         if (
-            eventType == Events.PRINT_DONE or
-            eventType == Events.PRINT_FAILED or
-            eventType == Events.PRINT_CANCELLED
+            eventType == Events.PRINT_DONE
+            or eventType == Events.PRINT_FAILED
+            or eventType == Events.PRINT_CANCELLED
         ):
             self.lastPrintOdometer = None
             self.lastPrintOdometerLoad = None
 
     def handlePrintingGCode(self, command):
         if (
-            not hasattr(self, "lastPrintOdometerLoad") or
-            self.lastPrintOdometerLoad == None
+            not hasattr(self, "lastPrintOdometerLoad")
+            or self.lastPrintOdometerLoad == None
         ):
             return
 
@@ -56,13 +57,17 @@ class PrinterHandler():
     def commitSpoolUsage(self):
         peek_stats_helpers = self.lastPrintOdometerLoad.send(False)
 
-        current_extrusion_stats = copy.deepcopy(peek_stats_helpers['get_current_extrusion_stats']())
+        current_extrusion_stats = copy.deepcopy(
+            peek_stats_helpers["get_current_extrusion_stats"]()
+        )
 
-        peek_stats_helpers['reset_extrusion_stats']()
+        peek_stats_helpers["reset_extrusion_stats"]()
 
         selectedSpoolIds = self._settings.get([SettingsKeys.SELECTED_SPOOL_IDS])
 
-        for toolIdx, toolExtrusionLength in enumerate(current_extrusion_stats['extrusionAmount']):
+        for toolIdx, toolExtrusionLength in enumerate(
+            current_extrusion_stats["extrusionAmount"]
+        ):
             selectedSpool = None
 
             try:
@@ -70,27 +75,25 @@ class PrinterHandler():
             except:
                 self._logger.info("Extruder '%s', spool id: none", toolIdx)
 
-            if (
-                not selectedSpool or
-                selectedSpool.get('spoolId', None) == None
-            ):
+            if not selectedSpool or selectedSpool.get("spoolId", None) == None:
                 continue
 
-            selectedSpoolId = selectedSpool['spoolId']
+            selectedSpoolId = selectedSpool["spoolId"]
 
             self._logger.info(
                 "Extruder '%s', spool id: %s, usage: %s",
                 toolIdx,
                 selectedSpoolId,
-                toolExtrusionLength
+                toolExtrusionLength,
             )
 
-            result = self.getSpoolmanConnector().handleCommitSpoolUsage(selectedSpoolId, toolExtrusionLength)
+            result = self.getSpoolmanConnector().handleCommitSpoolUsage(
+                selectedSpoolId, toolExtrusionLength
+            )
 
-            if result.get('error', None):
+            if result.get("error", None):
                 self.triggerPluginEvent(
-                    Events.PLUGIN_SPOOLMAN_SPOOL_USAGE_ERROR,
-                    result['error']
+                    Events.PLUGIN_SPOOLMAN_SPOOL_USAGE_ERROR, result["error"]
                 )
 
                 return
@@ -98,8 +101,8 @@ class PrinterHandler():
             self.triggerPluginEvent(
                 Events.PLUGIN_SPOOLMAN_SPOOL_USAGE_COMMITTED,
                 {
-                    'toolIdx': toolIdx,
-                    'spoolId': selectedSpoolId,
-                    'extrusionLength': toolExtrusionLength,
-                }
+                    "toolIdx": toolIdx,
+                    "spoolId": selectedSpoolId,
+                    "extrusionLength": toolExtrusionLength,
+                },
             )

--- a/octoprint_Spoolman/modules/PrinterUtils.py
+++ b/octoprint_Spoolman/modules/PrinterUtils.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 
 import math
 
+
 class PrinterUtils:
     def getCurrentJobFilamentUsage(self):
         printer = self._printer
@@ -13,31 +14,33 @@ class PrinterUtils:
             "jobHasFilamentLengthData": False,
         }
 
-        if ("job" not in printer.get_current_data()):
+        if "job" not in printer.get_current_data():
             return result
 
         jobData = printer.get_current_data()["job"]
 
-        if ("file" not in jobData):
+        if "file" not in jobData:
             return result
 
         fileData = jobData["file"]
         origin = fileData["origin"]
         path = fileData["path"]
 
-        if (origin == None or path == None):
+        if origin == None or path == None:
             return result
 
         metadata = fileManager.get_metadata(origin, path)
 
-        if ("analysis" not in metadata or "filament" not in metadata["analysis"]):
+        if "analysis" not in metadata or "filament" not in metadata["analysis"]:
             return result
 
         # Unused tools (eg. with 3 tools, only 1 & 3 are used) are still present on the list
         for toolName, toolData in metadata["analysis"]["filament"].items():
             toolIndex = int(toolName[4:])
 
-            result["jobFilamentLengthsPerTool"] += [0.0] * (toolIndex + 1 - len(result["jobFilamentLengthsPerTool"]))
+            result["jobFilamentLengthsPerTool"] += [0.0] * (
+                toolIndex + 1 - len(result["jobFilamentLengthsPerTool"])
+            )
             result["jobFilamentLengthsPerTool"][toolIndex] = toolData["length"]
 
             result["jobHasFilamentLengthData"] = True
@@ -45,7 +48,9 @@ class PrinterUtils:
         return result
 
     @staticmethod
-    def getFilamentUsageDataPerTool(filamentLengthPerTool, selectedSpoolsPerTool, spoolsAvailable):
+    def getFilamentUsageDataPerTool(
+        filamentLengthPerTool, selectedSpoolsPerTool, spoolsAvailable
+    ):
         usageDataPerTool = {}
 
         for toolIdx, toolExtrusionLength in enumerate(filamentLengthPerTool):
@@ -60,8 +65,12 @@ class PrinterUtils:
 
             if toolSpoolId != None:
                 toolSpool = next(
-                    (spool for spool in spoolsAvailable if str(spool["id"]) == toolSpoolId),
-                    None
+                    (
+                        spool
+                        for spool in spoolsAvailable
+                        if str(spool["id"]) == toolSpoolId
+                    ),
+                    None,
                 )
 
             if not toolSpool:
@@ -77,9 +86,9 @@ class PrinterUtils:
             filamentDiameter = toolSpool["filament"]["diameter"]
 
             toolExtrusionWeight = PrinterUtils.getFilamentWeight(
-                length = toolExtrusionLength,
-                density = filamentDensity,
-                diameter = filamentDiameter,
+                length=toolExtrusionLength,
+                density=filamentDensity,
+                diameter=filamentDiameter,
             )
 
             usageDataPerTool[toolIdxStr] = {
@@ -92,7 +101,7 @@ class PrinterUtils:
 
     @staticmethod
     def getFilamentWeight(length, density, diameter):
-        radius = diameter / 2.0;
+        radius = diameter / 2.0
         volume = length * math.pi * (radius * radius) / 1000
         weight = volume * density
 

--- a/octoprint_Spoolman/modules/SpoolmanConnector.py
+++ b/octoprint_Spoolman/modules/SpoolmanConnector.py
@@ -4,8 +4,17 @@ from __future__ import absolute_import
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
-class SpoolmanConnector():
-    def __init__(self, instanceUrl, logger, verifyConfig, apiKeyHeader = None, apiKey = None, isRetryLogicEnabled = True):
+
+class SpoolmanConnector:
+    def __init__(
+        self,
+        instanceUrl,
+        logger,
+        verifyConfig,
+        apiKeyHeader=None,
+        apiKey=None,
+        isRetryLogicEnabled=True,
+    ):
         self.instanceUrl = self._cleanupInstanceUrl(instanceUrl)
         self._logger = logger
         self.verifyConfig = verifyConfig
@@ -17,7 +26,7 @@ class SpoolmanConnector():
         trailingSlash = "/"
 
         if value.endswith(trailingSlash):
-            value = value[:-len(trailingSlash)]
+            value = value[: -len(trailingSlash)]
 
         return value
 
@@ -27,7 +36,7 @@ class SpoolmanConnector():
         return self.instanceUrl + apiPath
 
     def _createSpoolmanEndpointUrl(self, endpoint):
-        return self._createSpoolmanApiUrl() + endpoint;
+        return self._createSpoolmanApiUrl() + endpoint
 
     def _buildRequestHeaders(self):
         headers = {}
@@ -49,7 +58,9 @@ class SpoolmanConnector():
         self._logger.error("[Spoolman API] request failed with status %s" % statusCode)
 
     def _logSpoolmanSuccess(self, response):
-        self._logger.debug("[Spoolman API] request succeeded with status %s" % response.status_code)
+        self._logger.debug(
+            "[Spoolman API] request succeeded with status %s" % response.status_code
+        )
 
     def _precheckSpoolman(self):
         if not self.instanceUrl:
@@ -78,13 +89,12 @@ class SpoolmanConnector():
                 "code": code,
             },
         }
-    def _handleSpoolmanError(self, response, customError = None):
+
+    def _handleSpoolmanError(self, response, customError=None):
         self._logSpoolmanError(response)
 
         if customError != None:
-            return {
-                "error": customError
-            }
+            return {"error": customError}
 
         return {
             "error": {
@@ -98,7 +108,7 @@ class SpoolmanConnector():
     def handleGetSpoolsAvailable(self):
         precheckResult = self._precheckSpoolman()
 
-        if precheckResult and precheckResult.get('error', False):
+        if precheckResult and precheckResult.get("error", False):
             return precheckResult
 
         endpointUrl = self._createSpoolmanEndpointUrl("/spool")
@@ -108,8 +118,8 @@ class SpoolmanConnector():
         try:
             response = requests.get(
                 endpointUrl,
-                verify = self.verifyConfig,
-                headers = self._buildRequestHeaders()
+                verify=self.verifyConfig,
+                headers=self._buildRequestHeaders(),
             )
         except Exception as caughtException:
             return self._handleSpoolmanConnectionError(caughtException)
@@ -121,16 +131,12 @@ class SpoolmanConnector():
 
         data = response.json()
 
-        return {
-            "data": {
-                "spools": data
-            }
-        }
+        return {"data": {"spools": data}}
 
     def handleCommitSpoolUsage(self, spoolId, spoolUsedLength):
         precheckResult = self._precheckSpoolman()
 
-        if precheckResult and precheckResult.get('error', False):
+        if precheckResult and precheckResult.get("error", False):
             return precheckResult
 
         spoolIdStr = str(spoolId)
@@ -153,15 +159,13 @@ class SpoolmanConnector():
                         "[Spoolman API] retrying request (previous status: %s, error: %s) (retries left: %s)",
                         lastStatus if lastStatus else "unknown",
                         lastError if lastError else "unknown",
-                        self.total
+                        self.total,
                     )
 
         retryCount = 1 if not self.isRetryLogicEnabled else 3
 
         retries = RetryWithLogger(
-            total = retryCount,
-            backoff_factor = 1,
-            status_forcelist = [ 500, 502, 503, 504 ]
+            total=retryCount, backoff_factor=1, status_forcelist=[500, 502, 503, 504]
         )
 
         try:
@@ -171,12 +175,12 @@ class SpoolmanConnector():
             session.mount(self.instanceUrl, HTTPAdapter(max_retries=retries))
 
             response = session.put(
-                url = endpointUrl,
-                json = {
-                    'use_length': spoolUsedLength,
+                url=endpointUrl,
+                json={
+                    "use_length": spoolUsedLength,
                 },
-                headers = self._buildRequestHeaders(),
-                timeout = 1
+                headers=self._buildRequestHeaders(),
+                timeout=1,
             )
         except Exception as caughtException:
             return self._handleSpoolmanConnectionError(caughtException)
@@ -193,7 +197,7 @@ class SpoolmanConnector():
                         "spoolId": spoolIdStr,
                         "usedLength": spoolUsedLength,
                     },
-                }
+                },
             )
 
         if response.status_code != 200:
@@ -201,6 +205,4 @@ class SpoolmanConnector():
 
         self._logSpoolmanSuccess(response)
 
-        return {
-            "data": {}
-        }
+        return {"data": {}}

--- a/octoprint_Spoolman/static/js/Spoolman_modal_confirmSpool.js
+++ b/octoprint_Spoolman/static/js/Spoolman_modal_confirmSpool.js
@@ -243,6 +243,8 @@ $(() => {
             isLoadingData: ko.observable(true),
             loadingError: ko.observable(undefined),
 
+			renumberSpoolStart: ko.observable(Boolean(getPluginSettings().renumberSpoolStart())),
+
             detectedProblems: ko.observable([]),
             selectedSpoolsByToolIdx: ko.observable([]),
         };

--- a/octoprint_Spoolman/static/js/Spoolman_modal_selectSpool.js
+++ b/octoprint_Spoolman/static/js/Spoolman_modal_selectSpool.js
@@ -175,6 +175,8 @@ $(() => {
             searchFilter: ko.observable(""),
             sortField: ko.observable('id'),
             sortDirection: ko.observable('asc'),
+			
+			renumberSpoolStart: ko.observable(Boolean(getPluginSettings().renumberSpoolStart())),
 
             tableAttributeVisibility: {
                 id: true,

--- a/octoprint_Spoolman/static/js/Spoolman_sidebar.js
+++ b/octoprint_Spoolman/static/js/Spoolman_sidebar.js
@@ -99,6 +99,7 @@ $(() => {
 
             self.templateData.optionalFieldVisibility.lotNumber(Boolean(getPluginSettings().showLotNumberInSidebar()));
             self.templateData.optionalFieldVisibility.spoolID(Boolean(getPluginSettings().showSpoolIdInSidebar()));
+			self.templateData.renumberSpoolStart(Boolean(getPluginSettings().renumberSpoolStart()));
         };
 
         /**
@@ -227,6 +228,8 @@ $(() => {
                 lotNumber: ko.observable(false),
                 spoolID: ko.observable(false),
             },
+
+			renumberSpoolStart: ko.observable(false),
 
             modals: {
                 selectSpool: {
@@ -461,12 +464,15 @@ $(() => {
                 spoolmanUrl: getPluginSettings().spoolmanUrl(),
                 showLotNumberInSidebar: getPluginSettings().showLotNumberInSidebar(),
                 showSpoolIdInSidebar: getPluginSettings().showSpoolIdInSidebar(),
+				renumberSpoolStart: getPluginSettings().renumberSpoolStart(),
             };
 
             if (previousSettings.spoolmanUrl !== newSettings.spoolmanUrl) {
                 previousSettings.spoolmanUrl = newSettings.spoolmanUrl;
                 pluginSpoolmanApi.getSpoolmanSpools.invalidate();
             }
+
+            // TODO: update the view on settings saved
 
             if (
                 previousSettings.showLotNumberInSidebar !== newSettings.showLotNumberInSidebar ||

--- a/octoprint_Spoolman/templates/Spoolman_modal_confirmspool.jinja2
+++ b/octoprint_Spoolman/templates/Spoolman_modal_confirmspool.jinja2
@@ -102,7 +102,7 @@
                         <div style="display: flex;">
                             <!-- ko if: $parent.templateData.selectedSpoolsByToolIdx().length > 1 -->
                                 <div class="tool-idx" style="margin-right: 0.25em;">
-                                    <b>Tool #<span data-bind="text: $index()"></span>:</b>
+                                    <b>Tool #<span data-bind="text: $parent.templateData.renumberSpoolStart() ? $index() +1 : $index()"></span>:</b>
                                 </div>
                             <!-- /ko -->
 
@@ -151,7 +151,7 @@
                         <div style="display: flex;">
                             <!-- ko if: $parent.templateData.selectedSpoolsByToolIdx().length > 1 -->
                                 <div class="tool-idx" style="margin-right: 0.25em;">
-                                    <b>Tool #<span data-bind="text: $index()"></span>:</b>
+                                    <b>Tool #<span data-bind="text: $parent.templateData.renumberSpoolStart() ? $index() +1 : $index()"></span>:</b>
                                 </div>
                             <!-- /ko -->
 

--- a/octoprint_Spoolman/templates/Spoolman_settings.jinja2
+++ b/octoprint_Spoolman/templates/Spoolman_settings.jinja2
@@ -305,7 +305,53 @@
                         </div>
                     </div>
                 </div>
-                <hr>
+                <div class="control-group">
+                    <label
+                        class="control-label"
+                        for="settings-spoolman-display-settings-showLocationColumnInSpoolSelectModal"
+                    >
+                        Show Location column in Spool Select Modal
+                    </label>
+                    <div class="controls">
+                        <div>
+                            <input
+                                id="settings-spoolman-display-settings-showLocationColumnInSpoolSelectModal"
+                                type="checkbox"
+                                class="text-left"
+                                data-bind="checked: pluginSettings.showLocationColumnInSpoolSelectModal"
+                            >
+                        </div>
+                        <div style="margin-top: 0.25em">
+                            <small>
+                                If enabled, the "Location" column will be displayed in the Spool Select Modal. The column will show the location of the spool, if available.
+                            </small>
+                        </div>
+                    </div>
+                </div>
+				<hr>
+				<div class="control-group">
+                    <label
+                        class="control-label"
+                        for="settings-spoolman-display-settings-renumberSpoolStart"
+                    >
+                        Renumber Tools to Start at #1 in Sidebar
+                    </label>
+                    <div class="controls">
+                        <div>
+                            <input
+                                id="settings-spoolman-display-settings-renumberSpoolStart"
+                                type="checkbox"
+                                class="text-left"
+                                data-bind="checked: pluginSettings.renumberSpoolStart"
+                            >
+                        </div>
+                        <div style="margin-top: 0.25em">
+                            <small>
+                                If enabled, tools will be renumbered to start at #1 in the sidebar instead of #0. This will make tools match the numbers printed on a Prusa MMU, for example. 
+                            </small>
+                        </div>
+                    </div>
+                </div>
                 <div class="control-group">
                     <label
                         class="control-label"
@@ -325,29 +371,6 @@
                         <div style="margin-top: 0.25em">
                             <small>
                                 If enabled, a shortened version (maximum of 9 characters) of the "Lot Number" will be shown in the sidebar when a spool is assigned to a tool. The full lot number is visible if you hover over the shortened version.
-                            </small>
-                        </div>
-                    </div>
-                </div>
-                <div class="control-group">
-                    <label
-                        class="control-label"
-                        for="settings-spoolman-display-settings-showSpoolIdInSidebar"
-                    >
-                        Show Spool ID in Sidebar
-                    </label>
-                    <div class="controls">
-                        <div>
-                            <input
-                                id="settings-spoolman-display-settings-showSpoolIdInSidebar"
-                                type="checkbox"
-                                class="text-left"
-                                data-bind="checked: pluginSettings.showSpoolIdInSidebar"
-                            >
-                        </div>
-                        <div style="margin-top: 0.25em">
-                            <small>
-                                If enabled, the ID of the selected spool will be shown in the sidebar info.
                             </small>
                         </div>
                     </div>

--- a/octoprint_Spoolman/templates/Spoolman_sidebar.jinja2
+++ b/octoprint_Spoolman/templates/Spoolman_sidebar.jinja2
@@ -77,7 +77,7 @@
                         <div class="sidebar-spool-info">
                             <!-- ko if: $parent.templateData.selectedSpoolsByToolIdx().length > 1 -->
                                 <div>
-                                    <b>Tool #<span data-bind="text: $index()"></span>:</b>
+                                    <b>Tool #<span data-bind="text: $parent.templateData.renumberSpoolStart() ? $index() +1 : $index()"></span>:</b>
                                 </div>
                             <!-- /ko -->
                             <div>
@@ -127,7 +127,7 @@
                         <div class="sidebar-spool-info">
                             <!-- ko if: $parent.templateData.selectedSpoolsByToolIdx().length > 1 -->
                                 <div>
-                                    <b>Tool #<span data-bind="text: $index()"></span>:</b>
+                                    <b>Tool #<span data-bind="text: $parent.templateData.renumberSpoolStart() ? $index() +1 : $index()"></span>:</b>
                                 </div>
                             <!-- /ko -->
                             <div>

--- a/octoprint_Spoolman/templates/Spoolman_sidebar_modal_selectspool.jinja2
+++ b/octoprint_Spoolman/templates/Spoolman_sidebar_modal_selectspool.jinja2
@@ -18,7 +18,7 @@
     <div class="modal-body">
         <div>
             <div>
-                Tool #<span data-bind="text: templateData.toolIdx()"></span>:
+                Tool #<span data-bind="text: templateData.renumberSpoolStart() ? templateData.toolIdx() + 1 : templateData.toolIdx()"></span>:
                 &nbsp;
 
                 <!-- ko if: templateData.toolCurrentSpool() -->

--- a/octoprint_Spoolman/thirdparty/gcodeInterpreter.py
+++ b/octoprint_Spoolman/thirdparty/gcodeInterpreter.py
@@ -379,9 +379,7 @@ class gcode:
             offsets += [(0, 0)] * (max_extruders - len(offsets))
 
         def get_current_extrusion_stats():
-            return {
-                'extrusionAmount': maxExtrusion
-            }
+            return {"extrusionAmount": maxExtrusion}
 
         # Reset extrusion stats without affecting other temporary states
         def reset_extrusion_stats():
@@ -390,8 +388,8 @@ class gcode:
                 totalExtrusion[toolIndex] = 0.0
 
         peek_stats_helpers = {
-            'get_current_extrusion_stats': get_current_extrusion_stats,
-            'reset_extrusion_stats': reset_extrusion_stats,
+            "get_current_extrusion_stats": get_current_extrusion_stats,
+            "reset_extrusion_stats": reset_extrusion_stats,
         }
 
         while True:


### PR DESCRIPTION
This adds another feature requested in #66, to renumber the tools starting at one rather than zero for multi-tool printers.

<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes. Please provide context & motivation for the changes. -->
This adds a checkbox to Display Settings to renumber the spools in the sidebar starting from one. Black was also run on the Python files.

## Related Issue / Discussion
<!--- Pull requests should be related to open issues or discussions. -->
<!--- Please follow the guide provided in CONTRIBUTING.md file, before submitting a new Pull request. -->
<!--- Please link to the issue / discussion here: -->
See issue #66.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and what testing steps have been taken to verify the changes' correctness. -->
<!--- Please validate if other functionalities have not been negatively affected. -->
This has been tested in the provided Docker development environment and on a production OctoPrint system running on a Raspberry Pi 3 running OctoPrint 1.11.7 connected to a Prusa i3 MK3S+ with MMU3. As far as I can tell, the rest of the plugin has been unaffected.

## Screenshots (if appropriate):

**With new feature off:**
<img width="388" height="628" alt="image" src="https://github.com/user-attachments/assets/6b436b40-bf1c-4d6c-ace9-3675a71f4da4" />
**With new feature on:**
<img width="397" height="635" alt="image" src="https://github.com/user-attachments/assets/2cdf44c3-5b27-4e50-8414-efafe37a74c3" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have verified that my changes do not break the overall functionality of the plugin.
